### PR TITLE
Create testing example

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "mocha": "^5.2.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "./projectUtils/test_script.sh"
   },
   "repository": {
     "type": "git",

--- a/projectUtils/test_script.sh
+++ b/projectUtils/test_script.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+bc19compile -f -d ./bots/psuteam7bot/ -o ./projectUtils/psuteam7botCompiled.js
+node ./projectUtils/unitTestPrep.js
+node node_modules/.bin/mocha

--- a/projectUtils/unitTestPrep.js
+++ b/projectUtils/unitTestPrep.js
@@ -1,0 +1,57 @@
+/**
+ * unitTestPrep.js
+ * 
+ * Script that checks for compiled version of our robot and appends a list of exports.
+ * Goal is to ensure that the compiled file can be required so all components therein 
+ * (i.e. all the .js files in our bot directory) can be exported for testing. Expectation
+ * is that exportable object is named the same as the file. 
+ * E.g. If a file is called 'pilgrim.js', the 'pilgrim.js' file is exporting an object named
+ * 'pilgrim' with a line of code like "export default pilgrim";
+ */
+
+const fs = require('fs');
+const compiledCodePath = 'projectUtils/psuteam7botCompiled.js';
+
+//Check if compiled code exists, exit if not
+if(!fs.existsSync(compiledCodePath)) {
+    console.log("Error - Bot code has not been compiled into single module. Please compile before running script");
+    process.exit(1);
+}
+
+//Find all files in bot directory
+fs.readdir('bots/psuteam7bot', function(err, files) {
+    let outputToWrite = '';
+    let stringifiedNames = '';
+
+    if(err) {
+        console.log(err);
+        process.exit(1);
+    }
+
+    //For each file name, add to stringified list of exported objects
+    for(let i = 0; i < files.length; i++) {
+        //If file is robot.js, need to export "MyRobot" specifically as distinct class name
+        if (files[i] === 'robot.js') {
+            stringifiedNames += 'MyRobot';
+        //Otherwise, just append filename without '.js' extension, as name should match exported object name
+        } else {
+            stringifiedNames += files[i].replace(/.js$/, '');
+        }
+        //Comma seperators for list, except for last item
+        if (i != (files.length -1)) {
+            stringifiedNames += ',';
+        }
+    }
+
+    //Create string line representing module.exports being set to all exported objects
+    //Should now be of form "module.exports = {object1, object2, pbject3, ...};"
+    //
+    outputToWrite = '\nmodule.exports = {' + stringifiedNames + '};'
+
+    fs.appendFile(compiledCodePath, outputToWrite, function(err) {
+        if(err) {
+            console.log(err)
+        }
+        process.exit(1);
+    });
+});

--- a/test/myRobot.unittests.js
+++ b/test/myRobot.unittests.js
@@ -1,0 +1,48 @@
+const mocha = require('mocha');
+const chai = require('chai');
+const MyRobot = require('../projectUtils/psuteam7botCompiled.js').MyRobot;
+
+/*Choose an assertion style. I am used to 'expect', but there is also 'should' and 'assert'
+Basically different ways of making assertions. See https://www.chaijs.com/guide/styles/ for more documentation
+Full Chai expect documentation for reference is here: https://www.chaijs.com/api/bdd/
+*/
+const expect = chai.expect;
+
+
+//'describe' serves as a way to represent of kind of test. Everything in this describe block are 'MyRobot Unit Tests'
+describe('MyRobot Unit Tests', function() {
+    //Everything in this block is an 'Exanple' test. Some categories might be 'Mining', 'Movement', 'Strategy', etc.
+    describe('Properties tests', function() {
+        //'it' is the actual test that is run, with expectations being evaluated
+        it('should be an MyRobot object', function(done) {
+            const bot = new MyRobot();
+            const type = typeof bot;
+
+            //Create various assertions 
+            expect(type).equals('object');
+            expect(bot).to.be.an.instanceof(MyRobot);
+            //Done is called at completion of test to know this specific test can terminate
+            done();
+        });
+
+        //Use multiple 'it' blocks to test different aspects for the broader 'describe' category
+        it('should have certain properties and lack others', function(done) {
+            const bot = new MyRobot();
+
+            expect(bot).to.have.property('id');
+            expect(bot).to.have.property('fuel');
+            expect(bot).to.have.property('karbonite');
+            expect(bot).to.not.have.property('ID');
+            expect(bot).to.not.have.property('nonExistantProperty');
+
+            done();
+        });
+
+        //You can also skip tests or entire 'describe' blocks - useful for tests that are unfinished.
+        //Similarly, there is a '.only' syntax to exclusively test an 'it' or 'describe' block
+        it.skip('test to ignore', function(done) {
+            //This test is not done
+            expect(true).equals(false);
+        })
+    });
+});


### PR DESCRIPTION
Finally got Mocha/Chai to work. The long and short of it is that by running 'npm test' from the root directory, all files in the 'test' folder will be run. Additionally, all testable units should use `require('../projectUtils/psuteam7botCompiled.js')` to get desired files to test (e.g. to test `pilgrim.js` which is exported as `export default pilgrim`, use `require('../projectUtils/psuteam7botCompiled.js').pilgrim`). More detailed descriptions of file changes below:

**`projectUtils` folder**
Created a folder to hold some scripts and output of compilation of our bot for testing purposes. Feel free to put other things in there if you like.

**unitTestPrep.js**
A little code to append `modules.exports = {module1, module2, ...};` to the end of the file containing all modules in one file, where a module is basically a file name in `bots/psuteam7bot/filename.js' which is exported as 'export default filename'. This syntax is important to maintain for testing to work!

**test_script.sh**
A script which compiles our bot's code into the file `projectUtils/psuteam7botCompiled.js` (putting all files/modules into one place), runs `unitTestPrep.js` to export all file modules, then runs mocha to test everything in the `test` directory. Note that you may have to make this file executable with `chmod` (hopefully I addressed this, but just a warning

**package.json**
Updated so running `npm test` from the root directory just runs `test_script.sh` and tests can execute!

**`test` folder**
Created test folder. Anything in here will be run by Mocha when you run `npm test` from the root directory.

**myRobot.unittests.js**
The main goal of this PR - a testing example! Very barebones and mostly to demo a few structural things, but I added lots of notes to help. Feel free to use this structure by creating new unit testing files in the `test` folder (such as `pilgrim.unittests.js` or `movement.unittests.js`, e.g.). I may also take on the QA role and add tests for work that is done by anyone.