### PR TITLE
Prophet squad movement deathball fix

### DIFF
--- a/bots/psuteam7bot/prophet.js
+++ b/bots/psuteam7bot/prophet.js
@@ -42,7 +42,7 @@ prophet.doAction = (self) => {
             {
                 const distance = movement.getDistance(self.base, robotElement);
                 //30, assuming defender moved at max speed (r^2= 4) for 5 turns (4*5 = 20), + 10 to account for the possibility of prophet spawning in different starting tiles
-                return distance < 49;
+                return distance <= 64;
             }
         });
 
@@ -56,7 +56,7 @@ prophet.doAction = (self) => {
         else
         {
             self.log("Base defenders = " + JSON.stringify(nearbyDefenders.length) + ", Assigned as an attacker");
-            self.squadSize = 10;
+            self.squadSize = 9; //-2, account for 1 defender and 1 trigger prophet, need to change squad detection if trigger prophet is to be part of squad
             self.role = "ATTACKER";
         }
     }
@@ -94,7 +94,7 @@ prophet.takeDefenderAction = (self) =>  {
 
 
     //Limited movement towards enemy castle (movement towards guard post)
-    if(self.me.turn < 5)
+    if(self.me.turn < 4)
     {
         if(self.path.length === 0)
         {
@@ -150,6 +150,7 @@ prophet.takeAttackerAction = (self) => {
     //Attack visible enemies
     if(attackable.length > 0)
     {
+        --self.me.turn;
         let attacking = attackable[0];
         self.log("Attacking " + combat.UNITTYPE[attacking.unit] + " at " + attacking.x + ", " +  attacking.y);
         return self.attack(attacking.x - self.me.x, attacking.y - self.me.y);
@@ -183,8 +184,8 @@ prophet.takeAttackerAction = (self) => {
         }
     }
 
-    //If first four turns, move away from allied base towards enemy base, else check if squadSize threshold is met and is 0
-    if(self.me.turn < 5)
+    //If first seven turns, move away from allied base towards enemy base, else check if squadSize threshold is met and is 0
+    if(self.me.turn < 6)
     {
         self.log('ATTACKER prophet ' + self.id + ' moving to rally point, Current: [' + self.me.x + ',' + self.me.y + ']')
         return movement.moveAlongPath(self);
@@ -205,8 +206,7 @@ prophet.takeAttackerAction = (self) => {
         self.log('ATTACKER prophet ' + self.id + ' squad threshold reached! Deathballing')
         self.squadSize = 0;
 
-        self.log('ATTACKER prophet ' + self.id + ' moving towards enemy base, Current: [' + self.me.x + ',' + self.me.y + ']')
-        return movement.moveAlongPath(self);
+        return;
     }
     //Should not fall through unless attacker with squadSize threshold not reached yet
     self.log('prophet ' + self.role + ' ' + self.me.id + ' doing nothing')


### PR DESCRIPTION
-Tweaks to prophets being assigned as Defenders even though the 'cap' should have been reached
-Only 1 defender prophet close to base 
-Attacker prophets move a bit farther away from base
-Tweaked squad size