### PR TITLE
Build more pilgrims at start

### DIFF
--- a/bots/psuteam7bot/castle.js
+++ b/bots/psuteam7bot/castle.js
@@ -1,6 +1,7 @@
 import {BCAbstractRobot, SPECS} from 'battlecode';
 import movement from './movement.js';
 import combat from './combat.js';
+import communication from './communication.js';
 
 const castle = {};
 
@@ -8,10 +9,36 @@ const castle = {};
 castle.doAction = (self) => {
 
     self.log("castle" + self.id + "taking turn.");
-    //Assume that there are enough resources to produce unit 'Pilgrim'
-    if(self.me.turn < 3)
+    //On first turn:
+    //  1. add to castleBuildQueue with pilgrims for each local karbonite depot
+    //  2. add to castleBuildQueue with pilgrims for each local fuel depot
+    //  3. add to castleBuildQueue a single prophet targeting the mirror castle.
+    //This ensures that all local depots are filled and a prophet will be built after
+    if(self.me.turn === 1)
     {
-        return castle.findUnitPlace(self, 'PILGRIM');
+        const karboniteDepots = movement.getResourcesInRange(self.me, 16, self.karbonite_map);
+        karboniteDepots.forEach(depot => {
+            self.castleBuildQueue.push({unit: "PILGRIM", x: depot.x, y: depot.y});
+        })
+        const fuelDepots = movement.getResourcesInRange(self.me, 16, self.fuel_map)
+        fuelDepots.forEach(depot => {
+            self.castleBuildQueue.push({unit: "PILGRIM", x: depot.x, y: depot.y});
+        })
+        const mirrorCastle = movement.getMirrorCastle(self.me, self.map)
+        self.castleBuildQueue.push({unit: "PROPHET", x: mirrorCastle.x, y: mirrorCastle.y});
+        self.log(self.castleBuildQueue)
+        return castle.buildFromQueue(self);
+    }
+    else if (self.castleBuildQueue.length > 0) 
+    {
+        self.log("BUILD QUEUE NON-EMPTY")
+        self.log(self.castleBuildQueue)
+        const botsInQueue = self.castleBuildQueue.length;
+        //Keep queue at reasonable size, adding another prophet as necessary so prophets are continually build
+        if (botsInQueue <= 5) {
+            self.castleBuildQueue.push(self.castleBuildQueue[botsInQueue-1]);
+        }
+        return castle.buildFromQueue(self);
     }
     else
     {
@@ -30,11 +57,31 @@ castle.findUnitPlace = (self, unitType) => {
             const location = {x: (self.me.x + i), y: (self.me.y +j)} 
             if(movement.isPassable(location, self.map, self.getVisibleRobotMap()))
             {
-                self.log('castle ' + self.id + ' building pilgrim at [' + (self.me.x+i) + ',' + (self.me.y+j) +']'); 
+                self.log('castle ' + self.id + ' building unit ' + unitType + ' at [' + (self.me.x+i) + ',' + (self.me.y+j) +']'); 
                 return self.buildUnit(SPECS[unitType], i, j);       
             }
         }
     }
     return;
 }
+
+/**
+ * Method to build next unit pushed on `castleBuildQueue`. Currently no checks that should be implemented
+ */
+castle.buildFromQueue = (self) => {
+    const nextBuild = self.castleBuildQueue[0];
+    //If you are able to build next unit, signal coordinates so it knows where to go and build it
+    if(self.fuel >= SPECS.UNITS[SPECS[nextBuild.unit]].CONSTRUCTION_FUEL && 
+       self.karbonite >= SPECS.UNITS[SPECS[nextBuild.unit]].CONSTRUCTION_KARBONITE) {
+        self.castleBuildQueue.shift();
+        self.signal(communication.positionToSignal(nextBuild, self.map), 2);
+        return castle.findUnitPlace(self, nextBuild.unit);
+    } else {
+        self.log('cannot build unit ' + nextBuild.unit + '- not enough resources');
+        return;
+    }
+}
+
+
+
 export default castle;

--- a/bots/psuteam7bot/communication.js
+++ b/bots/psuteam7bot/communication.js
@@ -1,4 +1,6 @@
 import {SPECS} from "battlecode";
+import combat from './combat.js';
+import movement from "./movement.js";
 const communication = {};
 
 /*Translate position object x and y to signal value
@@ -25,5 +27,37 @@ communication.signalToPosition = (signalValue, fullMap) => {
 
     return {x, y};
 }
+
+/**
+ * Method to get information on all castles and pass it into `self.teamCastles` array
+ */
+communication.initTeamCastleInformation = (self) => {
+    if (self.teamCastles.length > 0) {
+        self.log('Team castle locations already initialized - aborting method');
+        return false;
+    } else {
+        const maxDist = -2*Math.pow(self.map.length, 2)-1
+        const castles = combat.filterByTeam(self, combat.filterByUnitType(self.getVisibleRobots(), "CASTLE"), self.me.team);
+        //Initialize some basic information
+        castles.forEach(castle => {
+            if(castle.hasOwnProperty("x") && castle.hasOwnProperty("y")) {
+                self.teamCastles.push({id: castle.id, x: castle.x, y: castle.y});
+            } else {
+                self.teamCastles.push({id: castle.id, x: maxDist, y: maxDist});
+            }
+        });
+        //Sort so nearest castle is self.teamCastles[0]
+        self.teamCastles.sort((a,b) => {
+            if(movement.getDistance(self.me, a) > movement.getDistance(self.me, b)) {
+                return -1;
+            } else {
+                return 1;
+            }
+        });
+        return true;
+    }
+}
+
+
 
 export default communication;

--- a/bots/psuteam7bot/movement.js
+++ b/bots/psuteam7bot/movement.js
@@ -212,48 +212,39 @@ movement.isPassable = (location, fullMap, robotMap) => {
 }
 
 /**
-*Return an array of resource depot locations sorted by distance from location passed as parameter
-*Use Case: for pioneers?
-*Might exceed chess clock? remove if so...
-*TODO: Might be unnecessary
-*/
-/*
-movement.getSortedResourceList(location, resourceMap)
-{
-    const length = resourceMap.length;
-    var sortedArr = [];
-    var distArr = [];
-    var currentDist;
+ * Method to get an array of resource locations within a specified distance, sorted by distance.
+ * 
+ * @param location Position to check from
+ * @param maxDistance Maximum allowed distance from location
+ * @param resourceMap Either `karbonite_map` or `fuel_map`
+ * @return Array of resource locations sorted by distance (i.e. targets[0] will be closest)
+ */
+movement.getResourcesInRange = (location, maxDistance, resourceMap) => {
+    const targets = [];
+    let currentDist;
 
-    for (let y = 0; y < length; ++y) 
+    for (let y = 0; y < resourceMap.length; ++y) 
     {
-        for (let x = 0; x < length; ++x) 
+        for (let x = 0; x < resourceMap.length; ++x) 
         {
-            if (resourceMap[y][x]) 
+            if (resourceMap[y][x])
             {
                 currentDist = movement.getDistance(location, {x, y});
-
-                if(sortedArr.length === 0)
-                {
-                    sortedArr = [{x, y}];
-                    distArr = [currentDist];
-                }
-
-                for(let i = 0; i < sortedArr.length; ++i)
-                {
-                    if(currentDist < distArr[i])
-                    {
-                        sortedArr.splice(i, 0, {x, y});
-                        distArr.splice(i, 0, currentDist);
-                        break;
-                    }
-                }
+                if(currentDist <= maxDistance) {
+                    targets.push({x: x, y: y, distance: currentDist})
+                }                
             }
         }
     }
-    return sortedArr;
+    targets.sort((a,b) => {
+        if(a.distance < b.distance) {
+            return -1;
+        } else {
+            return 1;
+        }
+    });
+    return targets;
 }
-*/
 
 /**
 *The most simplest moveTowards, get location of a nearby passable adjacent tile, hopefully closer to destination

--- a/bots/psuteam7bot/movement.js
+++ b/bots/psuteam7bot/movement.js
@@ -462,25 +462,25 @@ movement.getDiagonalPatrolPosition = (myCastleLocation, fullMap) => {
  *         method thus needs to be returned by the action of whatever bot is calling it in order to make move.
  */
 movement.moveAlongPath = (self) => {
-    self.log("me: [" + self.me.x + "," + self.me.y + "]")
+    //self.log("me: [" + self.me.x + "," + self.me.y + "]")
     let nextMove = self.path.pop();
-    self.log("nextMove: [" + nextMove.x + "," + nextMove.y + "]")
+    //self.log("nextMove: [" + nextMove.x + "," + nextMove.y + "]")
 
     //If next move is viable, do it
     if(movement.isPassable(nextMove, self.map, self.getVisibleRobotMap())) {
         self.log("Unit " + self.me.id + " moving to: [" + nextMove.x + "," + nextMove.y + "]")
         return self.move(nextMove.x-self.me.x, nextMove.y-self.me.y);
     //If nextMove is destination (because path is empty), readd destination to path and wait to be moveable
-    } else if (self.path.length === 0) {
+    /*} else if (self.path.length === 0) {
         self.log("Final path position occupied - wait until unoccupied")
         self.path.push(nextMove);
-        return;
+        return;*/
     //If next move not viable, reset path by readding next move, attempt to adjust path accounting for bots
     } else {
         self.path.push(nextMove);
         //If adjustment successful, pop off new next move and go to it
         if(movement.adjustPath(self, self.me)) {
-            self.log(self.path);
+            //self.log(self.path);
             nextMove = self.path.pop();
             self.log("Unit " + self.me.id + " moving to: [" + nextMove.x + "," + nextMove.y + "]")
             return self.move(nextMove.x-self.me.x, nextMove.y-self.me.y);
@@ -519,8 +519,13 @@ movement.adjustPath = (self, newOrigin) => {
         //oldMoves.push(reconnectionPoint);
         reconnectionPoint = self.path.pop();
 
-        self.log("reconnectionPoint: [" + reconnectionPoint.x + "," + reconnectionPoint.y + "]");
+        //self.log("reconnectionPoint: [" + reconnectionPoint.x + "," + reconnectionPoint.y + "]");
     } while(!movement.isPassable(reconnectionPoint, self.map, self.getVisibleRobotMap()) && self.path.length > 0);
+
+    //If the last option is the final destination and that destination is a bot, adjust to a viable final location
+    if(self.path.length === 0 && !movement.isPassable(reconnectionPoint, self.map, self.getVisibleRobotMap())) {
+        reconnectionPoint = movement.findNearestLocation(self, reconnectionPoint);
+    }
     
     /*
         Make path from newOrigin to reconnectionPoint with A* pathfinding accounting for bots and reconnect with rest
@@ -539,6 +544,42 @@ movement.adjustPath = (self, newOrigin) => {
         self.path = oldPath;
         return false;
     }
+}
+
+/**
+ * Method to find a nearby square for a location if the location itself is not viable. Intended for use in
+ * `movement.adjustPath` in case you are trying to move on top of a castle.
+ * 
+ * @param self MyRobot object trying to move
+ * @param location Location to find a nearby square
+ * @return Returns a coordinate pair for a nearby location.
+ */
+movement.findNearestLocation = (self, location) => {
+    //Use Pilgrim's movable positions as example
+    const idealDirection = movement.getRelativeDirection(location, self.me);
+    const positions = movement.getMoveablePositions(2).sort((a, b) => {
+        if(a.r2 < b.r2) {
+            return -2;
+        } else if (a.r2 > b.r2) {
+            return 2;
+        } else {
+            if (a.dirIndex === idealDirection) {
+                return -1;
+            } else if(b.dirIndex === idealDirection) {
+                return 1;
+            } else {
+                return 0;
+            }
+        }
+    });
+
+    for(let i = 0; i < positions.length; i++) {
+        const position = {x: location.x+positions[i].x, y: location.y+positions[i].y};
+        if(movement.isPassable(position, self.map, self.getVisibleRobotMap())) {
+            return position;
+        }
+    }
+    return location;
 }
 
 /**

--- a/bots/psuteam7bot/pilgrim.js
+++ b/bots/psuteam7bot/pilgrim.js
@@ -1,5 +1,7 @@
 import {BCAbstractRobot, SPECS} from 'battlecode';
 import movement from './movement.js';
+import combat from './combat.js';
+import communiation from './communication.js';
 
 const pilgrim = {};
 pilgrim.maxKarbonite = SPECS.UNITS[SPECS.PILGRIM].KARBONITE_CAPACITY;
@@ -22,6 +24,11 @@ pilgrim.doAction = (self) => {
         self.log("Set base as " + JSON.stringify(self.base));
         //Gets nearby base, checks turn
         self.role = 'PIONEER'
+        communiation.initTeamCastleInformation(self);
+        //Set target base on castle signal
+        const {x, y} = communiation.signalToPosition(self.getRobot(self.teamCastles[0].id).signal, self.map)
+        self.target = {x: x, y: y};
+        self.log("pilgrim MINER " + self.id + " targeting depot at [" + self.target.x + "," + self.target.y + "]")
     }
 
     if(self.role === 'MINER') {

--- a/bots/psuteam7bot/pilgrim.js
+++ b/bots/psuteam7bot/pilgrim.js
@@ -1,7 +1,7 @@
 import {BCAbstractRobot, SPECS} from 'battlecode';
 import movement from './movement.js';
 import combat from './combat.js';
-import communiation from './communication.js';
+import communication from './communication.js';
 
 const pilgrim = {};
 pilgrim.maxKarbonite = SPECS.UNITS[SPECS.PILGRIM].KARBONITE_CAPACITY;
@@ -24,9 +24,9 @@ pilgrim.doAction = (self) => {
         self.log("Set base as " + JSON.stringify(self.base));
         //Gets nearby base, checks turn
         self.role = 'PIONEER'
-        communiation.initTeamCastleInformation(self);
+        communication.initTeamCastleInformation(self);
         //Set target base on castle signal
-        const {x, y} = communiation.signalToPosition(self.getRobot(self.teamCastles[0].id).signal, self.map)
+        const {x, y} = communication.signalToPosition(self.getRobot(self.teamCastles[0].id).signal, self.map)
         self.target = {x: x, y: y};
         self.log("pilgrim MINER " + self.id + " targeting depot at [" + self.target.x + "," + self.target.y + "]")
     }

--- a/bots/psuteam7bot/pilgrim.js
+++ b/bots/psuteam7bot/pilgrim.js
@@ -18,9 +18,9 @@ pilgrim.doAction = (self) => {
     }
     
     if (self.role === 'UNASSIGNED') {
-        //self.base = movement.findAdjacentBase(self);
+        self.base = movement.findAdjacentBase(self);
         //Tweaking to set base not directly on top of castle, because causing pathfinding issues
-        self.base = {x: self.me.x, y: self.me.y};
+        //self.base = {x: self.me.x, y: self.me.y};
         self.log("Set base as " + JSON.stringify(self.base));
         //Gets nearby base, checks turn
         self.role = 'PIONEER'

--- a/bots/psuteam7bot/prophet.js
+++ b/bots/psuteam7bot/prophet.js
@@ -28,7 +28,7 @@ prophet.doAction = (self) => {
         if(self.isRadioing(baseRobot))  //Check if base has broadcasted a signal on it's turn
         {
             //Get the message using baseRobot.signal and translate to position using helper function
-            self.potentialEnemyCastleLocation = [communication.signalToPosition(baseRobot.signal)];
+            self.potentialEnemyCastleLocation = [communication.signalToPosition(baseRobot.signal, self.map)];
             self.potentialEnemyCastleLocation.push(movement.getDiagonalPatrolPosition(self.base, self.map));
         }
         else

--- a/bots/psuteam7bot/robot.js
+++ b/bots/psuteam7bot/robot.js
@@ -15,11 +15,14 @@ class MyRobot extends BCAbstractRobot {
         this.role = "UNASSIGNED";                        //Role for unit (for strategy purposes)
         this.target = null;                              //Target destionation like {x: _, y: _}  
         this.base = null;                                //Closest (or original) castle/church like {x: _, y: _} 
+        this.teamCastles = [];                           //Array to hold info about friendly castles
+        this.enemyCastles = [];                          //Array to hold info about identified enemy castles
         this.path = [];                                  //Array representing sequence of moves towards target. `path.pop()` gets next move
         this.previous = null;                            //Previous tile traversed by unit like {x: _, y: _}, initialized to the spawning/ starting location
         this.potentialEnemyCastleLocation = null;
         this.occupiedResources = [];
         this.squadSize = null;                           //Squad size for squad movements
+        this.castleBuildQueue = [];                      //Queue for what units the castle should build. NOT related to which castles should build when
     }
     turn() {
         if(this.previous == null) {


### PR DESCRIPTION
Assorted changes, described by file:

**`castle.js`**

- Implemented a build queue, which contains an object like `{unit: "PILGRIM", x: 0, y: 10}` where `unit` is the name of the unit to build and `x,y` are coordinates for the castle to signal so the built unit knows what to target.
-On turn 1, the build queue is initialized with enough pilgrims to fill all resource depots within 16 R^2 of the castle. Then it continuously builds prophets. We can obviously tweak this as desired.
-Added a method to build the first unit on the queue if there are enough resources to do so. Otherwise, information stays at head of queue.

**`communication.js`**
- Created a method to identify initial information about all team castles, push corresponding object in  `this.teamCastles`,  and potentially fill in actual coordinates if they exist. Sorts the list by distance from the target so your home base (or yourself, if you are a castle) is the first item in the `this.teamCastles` array.

**`movement.js`**
- Reintroduced with some adjustments the `getResourcesInRange` function to find all resource depots of a specific type within a given range of an input location. Used by castles to identify all local depots and build enough pilgrims for that.
- Added hotfix in `moveAlongPath` that handles a case where a unit targeting a castle/another bot would cause it to stop moving (since it thinks the final location is occupied). Now if we get to this point, it will try to find a nearby, unoccupied location instead and create a path to there. Not 100% guaranteed to find a location (if the target is completely surrounded), but practically will fix our issue.
- Per the above point, added a `findNearestLocation` method to find a nearby square to a input location, prioritizing squares that are closer to the input location and ideally in between the bot and the location.

**`pilgrim.js`**
- Removed some annoying, excessive logs from previous testing and updated `self.base` back to the castle after the hotfix to find a nearby location if attempting to move onto the castle.

**`robot.js`**
- Added array properties for `teamCastles`, `enemyCastles`, and `castleBuildQueue`.