### PR TITLE
More unittest additions

### DIFF
--- a/bots/psuteam7bot/crusader.js
+++ b/bots/psuteam7bot/crusader.js
@@ -85,11 +85,13 @@ crusader.takeAttackerAction = (self) => {
     }
 
     //No enemy castle at target and there are more waypoint to check
-    if(self.potentialEnemyCastleLocation.length > 0 && movement.getDistance(self.me, self.target) <= 49)
+    if(self.potentialEnemyCastleLocation.length > 0 && movement.getDistance(self.me, self.target) <= 16)
     {
         //Assign new target waypoint
         self.potentialEnemyCastleLocation.shift();
-        self.target = self.potentialEnemyCastleLocation[0];
+        if(self.potentialEnemyCastleLocation.length != 0) {
+            self.target = self.potentialEnemyCastleLocation[0];
+        }
     }
 
     //TODO No more patrol waypoint, do nothing
@@ -117,12 +119,12 @@ crusader.takeAttackerAction = (self) => {
     {
         if(movement.hasFuelToMove(self, self.path[self.path.length-1])) {
             self.attackerMoves++;
+            self.log('ATTACKER crusader ' + self.id + ' moving to rally point, Current: [' + self.me.x + ',' + self.me.y + ']')
+            return movement.moveAlongPath(self);
         } else {
             self.log('ATTACKER crusader ' + self.id + ' waiting for more fuel to move to rally point');
             return;
         }
-        self.log('ATTACKER crusader ' + self.id + ' moving to rally point, Current: [' + self.me.x + ',' + self.me.y + ']')
-        return movement.moveAlongPath(self);
     }
     else if(self.squadSize === 0)
     {

--- a/bots/psuteam7bot/movement.js
+++ b/bots/psuteam7bot/movement.js
@@ -109,6 +109,44 @@ movement.rotateDirection = (direction, n) => {
 }
 
 /**
+ * Method to get directions between two different rotation indices from a starting direction index.
+ * Returns an array containing all directions from `rotationsLeft` rotations left or less from `dirIndex` 
+ * to `rotationsRight` rotations right or less from `dirIndex`.
+ * Used to get things like directions between a point (for example, anything perpendicular to or closer to
+ * the input direction would be `getDirectionsBetween(index, 2, 2)`).
+ * 
+ * @param dirIndex Starting index from which to make decisions
+ * @param rotationsLeft Non-negative number representing the max rotations to the left that should be included
+ * @param rotationsRight Non-negative number representing the max rotations to the right that should be included
+ * @return An array of directions that are between `rotationsLeft` rotations left of `dirIndex` and 
+ *         `rotationsRight` rotations right of `dirIndex`
+ * 
+ */
+movement.getDirectionsBetween = (dirIndex, rotationsLeft, rotationsRight) => {
+    const output = [];
+    const start = ((dirIndex-rotationsLeft) % 8 + 8) % 8;
+    const end = ((dirIndex+rotationsRight) % 8 + 8) % 8;
+    //console.log('s: ' + start + ' e: ' + end);
+
+    if(rotationsLeft + rotationsRight >= 7) {
+        return JSON.parse(JSON.stringify(movement.directions));
+    } else if (rotationsLeft + rotationsRight === 0) {
+        output.push(movement.directions[start]);
+        return output;
+    } else if (rotationsLeft + rotationsRight < 0) {
+        return output; //Empty
+    } else {
+        let i = start;
+        while (i !== end) {
+            output.push(movement.directions[i]);
+            i = (i+1) % 8;
+        }
+        output.push(movement.directions[end]); //Don't forget the end!
+        return output;
+    }
+}
+
+/**
 *Return difference of x-coord and y-coord between A and B
 *Input: A - a 'position/ location' object {x, y}
 *       B - a 'position/ location' object {x, y}

--- a/bots/psuteam7bot/prophet.js
+++ b/bots/psuteam7bot/prophet.js
@@ -81,12 +81,6 @@ prophet.takeDefenderAction = (self) =>  {
 
     if(attackable.length > 0)
     {
-        //Compensate guard post movement turn loss due to attacking
-        if(self.me.turn < 5)
-        {
-            --self.me.turn;
-        }
-
         let attacking = attackable[0];
         self.log("Attacking " + combat.UNITTYPE[attacking.unit] + " at " + attacking.x + ", " +  attacking.y);
         return self.attack(attacking.x - self.me.x, attacking.y - self.me.y);
@@ -94,8 +88,10 @@ prophet.takeDefenderAction = (self) =>  {
 
 
     //Limited movement towards enemy castle (movement towards guard post)
-    if(self.me.turn < 5)
+    if(self.attackerMoves < 5)
     {
+        //Reusing attacker move naming convention
+        self.attackerMoves++;
         if(self.path.length === 0)
         {
             if(movement.aStarPathfinding(self, self.me, self.potentialEnemyCastleLocation[0], false)) {

--- a/bots/psuteam7bot/prophet.js
+++ b/bots/psuteam7bot/prophet.js
@@ -186,7 +186,7 @@ prophet.takeAttackerAction = (self) => {
     }
 
     //If first seven turns, move away from allied base towards enemy base, else check if squadSize threshold is met and is 0
-    if(self.me.turn < 6)
+    if(self.attackerMoves < 6)
     {
         if(movement.hasFuelToMove(self, self.path[self.path.length-1])) {
             self.attackerMoves++;

--- a/bots/psuteam7bot/prophet.js
+++ b/bots/psuteam7bot/prophet.js
@@ -150,7 +150,6 @@ prophet.takeAttackerAction = (self) => {
     //Attack visible enemies
     if(attackable.length > 0)
     {
-        --self.me.turn;
         let attacking = attackable[0];
         self.log("Attacking " + combat.UNITTYPE[attacking.unit] + " at " + attacking.x + ", " +  attacking.y);
         return self.attack(attacking.x - self.me.x, attacking.y - self.me.y);
@@ -161,7 +160,9 @@ prophet.takeAttackerAction = (self) => {
     {
         //Assign new target waypoint
         self.potentialEnemyCastleLocation.shift();
-        self.target = self.potentialEnemyCastleLocation[0];
+        if(self.potentialEnemyCastleLocation.length != 0) {
+            self.target = self.potentialEnemyCastleLocation[0];
+        }
     }
 
     //TODO No more patrol waypoint, do nothing
@@ -187,8 +188,14 @@ prophet.takeAttackerAction = (self) => {
     //If first seven turns, move away from allied base towards enemy base, else check if squadSize threshold is met and is 0
     if(self.me.turn < 6)
     {
-        self.log('ATTACKER prophet ' + self.id + ' moving to rally point, Current: [' + self.me.x + ',' + self.me.y + ']')
-        return movement.moveAlongPath(self);
+        if(movement.hasFuelToMove(self, self.path[self.path.length-1])) {
+            self.attackerMoves++;
+            self.log('ATTACKER prophet ' + self.id + ' moving to rally point, Current: [' + self.me.x + ',' + self.me.y + ']')
+            return movement.moveAlongPath(self);
+        } else {
+            self.log('ATTACKER prophet ' + self.id + ' waiting for more fuel to move to rally point');
+            return;
+        }
     }
     else if(self.squadSize === 0)
     {

--- a/bots/psuteam7bot/prophet.js
+++ b/bots/psuteam7bot/prophet.js
@@ -47,7 +47,7 @@ prophet.doAction = (self) => {
         });
 
         //2 defenders towards mirror castle, should be enough to kill a crusader in 2 turns before it gets to attack range
-        if(nearbyDefenders.length < 2)
+        if(nearbyDefenders.length < 3)
         {
             self.log("Base defenders = " + JSON.stringify(nearbyDefenders.length) + ", Assigned as a defender");
             self.role = "DEFENDER";

--- a/projectUtils/mockGame.js
+++ b/projectUtils/mockGame.js
@@ -57,6 +57,21 @@ class mockBC19 {
     }
 
     /**
+     * Method to take a BCAbstractRobot object and update the game's record of this bot with its communication information.
+     * Necessary because the game refers to a simplified `robot` object which does not reference `BCAbstractRobot.me` inherently
+     * and does not automatically adjust when bot adjusted.
+     * 
+     * @param {*} BCAbsBot BCAbstractRobot passed in to update the corresponding `robot` object in `this.game`
+     */
+    _setCommunication(BCAbsBot) {
+        const gameBot = this.game.getItem(BCAbsBot.me.id);
+        gameBot.signal = BCAbsBot.me.signal;
+        gameBot.signal_radius = BCAbsBot.me.signal_radius;
+        gameBot.castle_talk = BCAbsBot.me.castle_talk;
+        this._updateBotReferences();
+    }
+
+    /**
      * Method to create a robot from scratch based on inputs and shell of full robot passed in as parameter
      * 
      * @param {Object} bot  MyRobot/BCAbstractRobot object shell to pass in so method knows what to fill in with proper data 
@@ -117,7 +132,6 @@ class mockBC19 {
             });
         }
     }
-
 
     /**
      * Method that will destroy any existing map information/bots a create fresh new NxN maps based on input. Note that:

--- a/test/crusader.unittests.js
+++ b/test/crusader.unittests.js
@@ -8,7 +8,7 @@ const movement = require('../projectUtils/psuteam7botCompiled.js').movement;
 const communication = require('../projectUtils/psuteam7botCompiled.js').communication;
 const expect = chai.expect;
 
-describe.only('Combat Unit Tests', function() {
+describe('Combat Unit Tests', function() {
     let mockGame;
     let myBot;
     let localCastle
@@ -90,7 +90,7 @@ describe.only('Combat Unit Tests', function() {
         });
     });
 
-    describe.only('takeAttackerAction() tests', function() {
+    describe('takeAttackerAction() tests', function() {
         it('ATTACKERS with no base should identify enemy castles', function(done) {
             myBot.path = [{x: 3, y: 3}];
             myBot.target = {x: 9, y: 3};
@@ -193,6 +193,22 @@ describe.only('Combat Unit Tests', function() {
             done();
         });
 
+        it("ATTACKERS with an empty path should create a path to target", function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns("moved successfully");
+            myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
+            myBot.target = {x: 9, y: 3};
+            myBot.attackerMoves = 6;
+            myBot.squadSize = 0;
+
+            output = crusader.takeAttackerAction(myBot);
+
+            expect(myBot.path[0]).to.eql(myBot.target);
+            expect(output).equals("moved successfully");
+            
+
+            done();
+        });
+
         it("ATTACKERS with a path should move for 6 turns iff they have fuel to move", function(done) {
             let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns("moved successfully");
             myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
@@ -248,7 +264,7 @@ describe.only('Combat Unit Tests', function() {
             expect(myBot.squadSize).equals(2);
             expect(output).to.be.undefined;
 
-            //Squad not big enough 
+            //Squad big enough
             mockGame.createNewRobot(new MyRobot(), 8, 3, 0, 3);
             output = crusader.takeAttackerAction(myBot);
 
@@ -256,6 +272,23 @@ describe.only('Combat Unit Tests', function() {
             expect(myBot.squadSize).equals(0);
             expect(output).to.be.undefined;
             
+
+            done();
+        });
+
+        it("ATTACKERS with squadSize set to 0 should rush towards target", function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns("moved successfully");
+            myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
+            myBot.path = [{x: 3, y: 3}];
+            myBot.target = {x: 9, y: 3};
+            myBot.attackerMoves = 6;
+            myBot.squadSize = 0;
+
+            output = crusader.takeAttackerAction(myBot);
+
+            expect(myBot.attackerMoves).equals(6);
+            expect(myBot.squadSize).equals(0);
+            expect(output).equals("moved successfully");
 
             done();
         });

--- a/test/crusader.unittests.js
+++ b/test/crusader.unittests.js
@@ -192,5 +192,72 @@ describe.only('Combat Unit Tests', function() {
 
             done();
         });
+
+        it("ATTACKERS with a path should move for 6 turns iff they have fuel to move", function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns("moved successfully");
+            myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
+            myBot.path = [{x: 3, y: 3}];
+            myBot.target = {x: 9, y: 3};
+
+            //Enough fuel, still turns to move
+            myBot.attackerMoves = 5;
+            myBot.fuel = 4;
+            output = crusader.takeAttackerAction(myBot);
+
+            expect(myBot.attackerMoves).equals(6);
+            expect(output).equals("moved successfully");
+
+            //Not enough fuel, still turns to move
+            myBot.attackerMoves = 5;
+            myBot.fuel = 3;
+            output = crusader.takeAttackerAction(myBot);
+
+            expect(myBot.attackerMoves).equals(5);
+            expect(output).to.be.undefined;
+            
+
+            done();
+        });
+
+        it("ATTACKERS after 6 turns should wait for squad and adjust squadSize accordingly", function(done) {
+            myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
+            myBot.path = [{x: 3, y: 3}];
+            myBot.target = {x: 9, y: 3};
+            myBot.attackerMoves = 6;
+            myBot.squadSize = 2;
+
+            //Squad not big enough
+            output = crusader.takeAttackerAction(myBot);
+
+            expect(myBot.attackerMoves).equals(6);
+            expect(output).to.be.undefined;
+
+            //Squad not big enough because bot of wrong type
+            mockGame.createNewRobot(new MyRobot(), 5, 3, 0, 4);
+            output = crusader.takeAttackerAction(myBot);
+
+            expect(myBot.attackerMoves).equals(6);
+            expect(myBot.squadSize).equals(2);
+            expect(output).to.be.undefined;
+
+            //Squad not big enough friendly crusader out of range
+            mockGame.createNewRobot(new MyRobot(), 8, 4, 0, 3);
+            output = crusader.takeAttackerAction(myBot);
+
+            expect(myBot.attackerMoves).equals(6);
+            expect(myBot.squadSize).equals(2);
+            expect(output).to.be.undefined;
+
+            //Squad not big enough 
+            mockGame.createNewRobot(new MyRobot(), 8, 3, 0, 3);
+            output = crusader.takeAttackerAction(myBot);
+
+            expect(myBot.attackerMoves).equals(6);
+            expect(myBot.squadSize).equals(0);
+            expect(output).to.be.undefined;
+            
+
+            done();
+        });
     });
 });

--- a/test/crusader.unittests.js
+++ b/test/crusader.unittests.js
@@ -1,0 +1,89 @@
+const mocha = require('mocha');
+const chai = require('chai');
+const mockBC19 = require('../projectUtils/mockGame.js');
+const MyRobot = require('../projectUtils/psuteam7botCompiled.js').MyRobot;
+const crusader = require('../projectUtils/psuteam7botCompiled.js').crusader;
+const combat = require('../projectUtils/psuteam7botCompiled.js').combat;
+const movement = require('../projectUtils/psuteam7botCompiled.js').movement;
+const communication = require('../projectUtils/psuteam7botCompiled.js').communication;
+const expect = chai.expect;
+
+describe.only('Combat Unit Tests', function() {
+    let mockGame;
+    let myBot;
+    let localCastle
+    let mapLength;
+    let output;
+
+    beforeEach(function() {
+        mapLength = 10;
+        myBot = new MyRobot();
+        localCastle = new MyRobot();
+        mockGame = new mockBC19('../projectUtils/psuteam7botCompiled.js');
+        mockGame.initEmptyMaps(mapLength);
+        //Alter so map is viewed as horizontally symmetric
+        mockGame.alterMap("map", [{x: 0, y: 0, value: false}, {x: 9, y: 0, value: false}])
+        mockGame.createNewRobot(localCastle, 0, 3, 0, 0);
+        mockGame.createNewRobot(myBot, 1, 3, 0, 3);
+    });
+
+    afterEach(function() {
+        mockGame.undoSinonMethods();
+    })
+
+    describe('doAction() tests', function() {
+        it("UNASSIGNED bots should become ATTACKERS if they can't find a base", function(done) {
+            const noBaseBot = new MyRobot();
+            mockGame.createNewRobot(noBaseBot, 0, 9, 9, 3);
+            output = crusader.doAction(noBaseBot);
+
+            expect(noBaseBot.base).to.be.null;
+            expect(noBaseBot.role).equals("ATTACKER");
+            expect(output).to.be.undefined;
+
+            done();
+        });
+
+        it("UNASSIGNED bots should use the radio signal from the base if one exists", function(done) {
+            let stubAttackerAction = mockGame.replaceMethod("crusader", "takeAttackerAction").returns('skipping attacker action');
+            let signalPos = communication.signalToPosition(17, mockGame.game.map);
+            localCastle.me.signal = 17;
+            localCastle.me.signal_radius = 2;
+            mockGame._setCommunication(localCastle);
+
+            output = crusader.doAction(myBot);
+
+            expect(myBot.base).to.eql({x: 0, y: 3});
+            expect(myBot.role).equals("ATTACKER");
+            expect(myBot.potentialEnemyCastleLocation).to.deep.include.members([
+                signalPos,    //Castle signal (could be anything)
+                {x: 9, y: 6}  //Diagonal patrol (relative to localCastle)
+            ]);
+            expect(output).equals('skipping attacker action');
+
+            done();
+        });
+
+        it("UNASSIGNED bots should use getAttackerPatrolPosition if radio signal from the base DNE", function(done) {
+            let stubAttackerAction = mockGame.replaceMethod("crusader", "takeAttackerAction").returns('skipping attacker action');
+
+            output = crusader.doAction(myBot);
+
+            expect(myBot.base).to.eql({x: 0, y: 3});
+            expect(myBot.role).equals("ATTACKER");
+            expect(myBot.potentialEnemyCastleLocation).to.deep.include.members([
+                {x: 9, y: 3}, //Mirror castle location (relative to localCastle)
+                {x: 9, y: 6}  //Diagonal patrol (relative to localCastle)
+            ]);
+            expect(output).equals('skipping attacker action');
+
+            done();
+        });
+    });
+
+    describe('takeAttackerAction() tests', function() {
+        it('should do things', function(done) {
+            done();
+        });
+    });
+});

--- a/test/movement.unittests.js
+++ b/test/movement.unittests.js
@@ -6,7 +6,7 @@ const movement = require('../projectUtils/psuteam7botCompiled.js').movement;
 const expect = chai.expect;
 
 
-describe.only('Movement Helpers Unit Tests', function() {
+describe('Movement Helpers Unit Tests', function() {
     let mockGame;
     let myBot;
     let output;

--- a/test/movement.unittests.js
+++ b/test/movement.unittests.js
@@ -114,6 +114,42 @@ describe('Movement Helpers Unit Tests', function() {
         });
     });
 
+    describe.only('getDirectionsBetween Returns Values Correctly', function(done) {
+        it('rotateDirection returns all values if sum of input geq  7', function(done) {
+            expect(movement.getDirectionsBetween(0, 7, 0)).to.eql(movement.directions);
+            expect(movement.getDirectionsBetween(0, 0, 7)).to.eql(movement.directions);
+            expect(movement.getDirectionsBetween(0, 3, 4)).to.eql(movement.directions);
+            expect(movement.getDirectionsBetween(0, -1, 8)).to.eql(movement.directions);
+            done();
+        });
+
+        it('rotateDirection returns single index if left and right sum to zero', function(done) {
+            expect(movement.getDirectionsBetween(0, 0, 0)).to.deep.include(movement.directions[0]);
+            expect(movement.getDirectionsBetween(1, -1, 1)).to.deep.include(movement.directions[2]);
+            expect(movement.getDirectionsBetween(2, 2, -2)).to.deep.include(movement.directions[0]);
+            done();
+        });
+
+        it('rotateDirection returns empty array if left and right sum is negative', function(done) {
+            expect(movement.getDirectionsBetween(0, -1, 0)).to.eql([]);
+            expect(movement.getDirectionsBetween(1, 0, -1)).to.eql([]);
+            expect(movement.getDirectionsBetween(2, -2, -3)).to.eql([]);
+            done();
+        });
+
+        it('rotateDirection returns all values between left and right properly', function(done) {
+            expect(movement.getDirectionsBetween(0, 1, 0)).to.have.members([movement.directions[0], movement.directions[7]])
+            expect(movement.getDirectionsBetween(0, 0, 1)).to.have.members(movement.directions.slice(0, 2));
+            expect(movement.getDirectionsBetween(0, 6, 0)).to.have.members([movement.directions[0], ...movement.directions.slice(2, 8)]);
+            expect(movement.getDirectionsBetween(0, 0, 6)).to.have.members(movement.directions.slice(0, 7));
+            expect(movement.getDirectionsBetween(3, 0, 1)).to.have.members(movement.directions.slice(3, 5));
+            expect(movement.getDirectionsBetween(5, 0, 1)).to.have.members(movement.directions.slice(5, 7));
+            done();
+        });
+
+
+    });
+
     describe('getDistanceXY Returns Values Correctly', function(done) {
         it('getDistanceXY Returns Valid Value Given Valid A And B Objects With Valid x And y Values', function(done) {
             const A = {x: 5, y: 7};

--- a/test/prophet.unittests.js
+++ b/test/prophet.unittests.js
@@ -31,7 +31,7 @@ describe.only('Prophet Unit Tests', function() {
         mockGame.undoSinonMethods();
     })
 
-    describe.only('doAction() tests', function() {
+    describe('doAction() tests', function() {
         it("Bots in unspecified roles should do nothing", function(done) {
             myBot.role = "TESTROLE";
             output = prophet.doAction(myBot);
@@ -133,7 +133,7 @@ describe.only('Prophet Unit Tests', function() {
 
     });
 
-    describe('takeAttackerAction() tests', function() {
+    describe.only('takeAttackerAction() tests', function() {
         it('ATTACKERS with no base should identify enemy castles', function(done) {
             myBot.path = [{x: 3, y: 3}];
             myBot.target = {x: 9, y: 3};
@@ -193,17 +193,17 @@ describe.only('Prophet Unit Tests', function() {
             expect(output['action']).equals('move');
 
             //Enemy out of attackable range
-            mockGame.createNewRobot(new MyRobot(), 5, 4, 1, 2);
+            mockGame.createNewRobot(new MyRobot(), 9, 4, 1, 2);
             output = prophet.takeAttackerAction(myBot);
 
             expect(output['action']).equals('move');
 
             //Enemy in attackable range
-            mockGame.createNewRobot(new MyRobot(), 5, 3, 1, 2); 
+            mockGame.createNewRobot(new MyRobot(), 9, 3, 1, 2); 
             output = prophet.takeAttackerAction(myBot);
 
             expect(output['action']).equals('attack');
-            expect(output['dx']).equals(4);
+            expect(output['dx']).equals(8);
             expect(output['dy']).equals(0);            
 
             done();
@@ -260,7 +260,7 @@ describe.only('Prophet Unit Tests', function() {
 
             //Enough fuel, still turns to move
             myBot.attackerMoves = 5;
-            myBot.fuel = 4;
+            myBot.fuel = 8;
             output = prophet.takeAttackerAction(myBot);
 
             expect(myBot.attackerMoves).equals(6);
@@ -268,7 +268,7 @@ describe.only('Prophet Unit Tests', function() {
 
             //Not enough fuel, still turns to move
             myBot.attackerMoves = 5;
-            myBot.fuel = 3;
+            myBot.fuel = 7;
             output = prophet.takeAttackerAction(myBot);
 
             expect(myBot.attackerMoves).equals(5);
@@ -300,7 +300,7 @@ describe.only('Prophet Unit Tests', function() {
             expect(output).to.be.undefined;
 
             //Squad not big enough friendly prophet out of range
-            mockGame.createNewRobot(new MyRobot(), 8, 4, 0, 4);
+            mockGame.createNewRobot(new MyRobot(), 9, 4, 0, 4);
             output = prophet.takeAttackerAction(myBot);
 
             expect(myBot.attackerMoves).equals(6);
@@ -308,7 +308,7 @@ describe.only('Prophet Unit Tests', function() {
             expect(output).to.be.undefined;
 
             //Squad big enough
-            mockGame.createNewRobot(new MyRobot(), 8, 3, 0, 4);
+            mockGame.createNewRobot(new MyRobot(), 9, 3, 0, 4);
             output = prophet.takeAttackerAction(myBot);
 
             expect(myBot.attackerMoves).equals(6);


### PR DESCRIPTION
Second PR of the unit test batch, this one for `crusader` and `prophet`. The testing of both is REALLY similar because of the copy/paste natural of the implementation, but there are a few more cases in `prophet.unittest` plus testing for `takeDefenderAction` and `fleeBehavior`. At this point I'm probably done with unit testing until the `crusader-prototype` branch gets merged up to `master`, but this should give us a really strong basis to feel comfortable with merging `crusader-prototype` once Andre's work gets added and these tests pass. Changes by file below per usual:

**`crusader.js`**
- Think I fixed a distinction between the crusader's shorter attack range (Line 88). Will have to watch this going forward.

**`movement.js`**
- Added a method called `getDirectionsBetween` that provides all unit directions coordinates between a certain number of rotations left of a direction to a certain number of rotations right of a initial direction. Intended for use by the `fleeBehavior` of the prophet since it was a little funky trying to identify the exact positions that work.

**`prophet.js`**
- Various bugfixes/tweaks, most notably the use of `attackerMoves` to gauge the number of moves away from the base prophets make (yes, this is for DEFENDERS, but might as well reuse the variable) and fixing `fleeBehavior` to work.

**`mockGame.js`**
- Added a method `_setCommunication` to update the game with any communication methods made to a `MyRobot` object. Needed because the game tracks `robot` object references that are copied by but do not reference `MyRobot.me`, so updating `MyRobot.me` wouldn't update the game (and thus other bots) with the proper information. Will be relevant for @Anushree-naik and the castle communication testing - may want to copy this method in if you end up using `mockGame`.

**`crusader.unittests.js`**
- Created tests for `doAction` and `takeAttackerAction`. Not going to go into implementation details, but thing I covered all (or almost all) possible sections of code.

**`prophet.unittests.js`**
- Created tests for `doAction` and `takeAttackerAction` that are basically clones of the `crusader` unittests with some additional implementation-specific tests
-Added tests for `takeDefenderAction` and `fleeBehavior`

**`movement.unittests.js`**
- Created unittests for the new `getDirectionsBetween` method