### PR TITLE
Quickfix branch

### DIFF
--- a/bots/psuteam7bot/castle.js
+++ b/bots/psuteam7bot/castle.js
@@ -44,11 +44,6 @@ castle.doAction = (self) => {
     }
     else if (self.me.turn <= 4) 
     {
-        if(self.me.turn > 5)
-        {
-            castle.checkUnitCastleTalk(self);
-            castle.signalNewUnitTarget(self);
-        }
         self.log("BUILD QUEUE NON-EMPTY")
         self.log(self.castleBuildQueue)
         const botsInQueue = self.castleBuildQueue.length;
@@ -65,7 +60,7 @@ castle.doAction = (self) => {
         const botsInQueue = self.castleBuildQueue.length;
         //Keep queue at reasonable size, adding another prophet as necessary so prophets are continually build
         if (botsInQueue <= 5) {
-            self.castleBuildQueue.push(self.castleBuildQueue[botsInQueue-1]);
+            self.castleBuildQueue.push({unit: "CRUSADER", x: self.target.x, y: self.target.y});
         }
         return castle.makeDecision(self, self.teamCastles);
     }
@@ -329,7 +324,7 @@ castle.signalNewUnitTarget = (self) =>{
         {
             const newTarget = self.pendingMessages.pop();
             self.signal(newTarget, self.map.length*self.map.length);
-            //self.log("Signal sent to units, " + newTarget + "---------------------------------------------------------------------------------------------------------");
+            self.log("Signal sent to units, " + newTarget + "---------------------------------------------------------------------------------------------------------");
         }
         else
         {

--- a/bots/psuteam7bot/castle.js
+++ b/bots/psuteam7bot/castle.js
@@ -138,7 +138,14 @@ castle.findPosition = (self) => {
     bots.forEach(foundCastle => {
         //Init an item in teamCastles for each on turn 2 once signals being sent
         if (turn == 2) {
-            self.teamCastles.push({id: foundCastle.id, x: maxDist, y: maxDist, buildCounter: buildCounter, signalBuilding: false})
+            self.teamCastles.push({
+                id: foundCastle.id,
+                x: maxDist, 
+                y: maxDist, 
+                buildCounter: buildCounter, 
+                signalBuilding: false,
+                mirrorCastleDestroyed: false
+            })
             self.log("Adding castle id="+foundCastle.id)
         }
 
@@ -292,6 +299,11 @@ castle.makeDecision = (self, otherCastles) => {
                         {
                             const removedCastle = self.enemyCastles.splice(k,1)[0];
                             enemyCastlesLength = self.enemyCastles.length;
+                            self.teamCastles.forEach(tc => {
+                                if(movement.positionsAreEqual(enemyCastle, movement.getMirrorCastle(tc, self.map))) {
+                                    tc.mirrorCastleDestroyed = true;
+                                }
+                            })
                             //self.log("Enemy castle removed from array----------------------------------------------------------------------------------------")
                             //self.log(self.target);
                             //self.log(removedCastle);

--- a/bots/psuteam7bot/castle.js
+++ b/bots/psuteam7bot/castle.js
@@ -128,8 +128,8 @@ castle.recordPosition = (self) => {
  */
 castle.findPosition = (self) => {
     //Filter by those that have a castle talk, since apparently unit does not appear if not in vision radius
-    const bots = self.getVisibleRobots().filter(bots =>{
-        return bots.team === self.me.team && bots.castle_talk > 0;
+    const bots = self.getVisibleRobots().filter(bot =>{
+        return bot.team === self.me.team && bot.castle_talk > 0;
     });
     let turn = self.me.turn;
     const buildCounter = {
@@ -144,6 +144,7 @@ castle.findPosition = (self) => {
         //Init an item in teamCastles for each on turn 2 once signals being sent
         if (turn == 2) {
             self.teamCastles.push({id: foundCastle.id, x: maxDist, y: maxDist, buildCounter: buildCounter, signalBuilding: false})
+            self.log("Adding castle id="+foundCastle.id)
         }
 
         self.teamCastles.forEach(teamCastle =>{

--- a/bots/psuteam7bot/castle.js
+++ b/bots/psuteam7bot/castle.js
@@ -58,8 +58,11 @@ castle.doAction = (self) => {
         castle.checkUnitCastleTalk(self);
         const hasSignalToSend = castle.signalNewUnitTarget(self);
         const botsInQueue = self.castleBuildQueue.length;
+        //If there are still pilgrims to build, prioritize that
+        if(botsInQueue > 0 && self.castleBuildQueue[0].unit == "PILGRIM") {
+            return castle.buildFromQueue(self);
         //Keep queue at reasonable size, adding another prophet as necessary so prophets are continually build
-        if (botsInQueue <= 5) {
+        } else if (botsInQueue <= 5) {
             self.castleBuildQueue.push({unit: "CRUSADER", x: self.target.x, y: self.target.y});
         }
         return castle.makeDecision(self, self.teamCastles, hasSignalToSend);

--- a/bots/psuteam7bot/communication.js
+++ b/bots/psuteam7bot/communication.js
@@ -119,7 +119,7 @@ communication.checkBaseSignalAndUpdateTarget = (self) => {
             //Reset target, path and set squadsize to 0, for all existing units of a base
             self.target = communication.signalToPosition(baseRobot[0].signal, self.map);
             self.path = [];
-            if(self.attackerMoves > 1)
+            if(self.attackerMoves > 5)
                 self.squadSize = 0;
             return true;
         }

--- a/bots/psuteam7bot/crusader.js
+++ b/bots/psuteam7bot/crusader.js
@@ -119,11 +119,6 @@ crusader.takeAttackerAction = (self) => {
     }
     else if(self.squadSize === 0)
     {
-        if(self.fuel < 100)
-        {
-            self.log('Low Fuel, Global fuel < 100, ATTACKER crusader ' + self.id + ' Standing by.')
-            return;
-        }
         self.log('ATTACKER crusader ' + self.id + ' moving towards enemy base, Current: [' + self.me.x + ',' + self.me.y + ']')
         return movement.moveAlongPath(self);
     }

--- a/test/communication.unittests.js
+++ b/test/communication.unittests.js
@@ -237,8 +237,8 @@ describe('Communication Helpers Unit Tests', function() {
             done();
         });
 
-        it('should change target, resets path, changes squadSize to 0 and returns true, if base signals and attackerMoves is > 1', function(done) {
-            myBot.attackerMoves = 3;
+        it('should change target, resets path, changes squadSize to 0 and returns true, if base signals and attackerMoves is > 5', function(done) {
+            myBot.attackerMoves = 6;
 
             baseBot.me.signal = communication.positionToSignal(newPos, mockGame.game.map);
             baseBot.me.signal_radius = 32;


### PR DESCRIPTION
Goal of this PR was to fix a couple high-level issues with macro execution after analyzing contents of `master`. Most tweaks are subtle but definitely let me know if there is something I did that might screw something else up. This is also not an exhaustive list of potential issues. For example, crusader's might set rally  point as far as 15+ tiles away (practically in enemy territory) so we might consider adjusting that later (likely based on distance between two castles). Additionally, the fuel check I added is pure guesswork at this point, so we will likely need to adjust that with more testing. Anyways, changes by file:

**`communication.js`**
- Tweaked `checkBaseSignalAndUpdateTarget` to only set `squadSize` to 0 if the bot had exceeded it's number of move turns. I believe this fixed an issue where the crusaders were all rushing to base and not rallying at all, possibly because of some signal confusion.

**`crusader.js`**
- Cut out the fuel check - to be done by castles before building

**`castle.js`**
- A few bug fixes, some of which were multiple small changes in different things. I'll try to explain all by concept and not by line of code:
1. Added `hasSignalToSend` as a parameter to `makeDecision` based on the result of `signalNewUnitTarget` (which now returns true if a signal was sent, false otherwise). Now if there is a signal to send, we skip building for a turn to ensure that the higher priority signal goes through. Fixes issue where target reassignment after castle destruction was being overridden by the signal sent to a newly created unit so it knows where to go. 
2. Added a check (Lines 62-63 of new code) that will attempt to build a pilgrim if there is one at head of `castleBuildQueue`. Fixes issue where castles wouldn't have enough karbonite to build enough right amount of initial pilgrims and then after turn 5 wouldn't build at all because  they were letting someone else build crusaders. Ensures that valuable resource generation is establishes as priority early on.
3. Added fuel check (new Lines 97-113) in `buildFromQueue` to determine whether the global fuel amount is so low that we should not build and prioritize moves/attacks from existing units. Currently basing this on a random equation we can tweak - see the comment in that section for a general explanation of the goal.
4.  Changed `findPosition` to initialize `x` and `y` of new team castle to be added to `teamCastles` to 0 and check on every turn for whether the talking castle is in `teamCastles` and adds it if not. Caught edge case where if the x- or y-coordinate of a castle was 0, its `castle_talk` would be ignored (since apparently `castle_talk` defaults to 0 or something, or possibly we can see the other team's communications? Yikes if so...).
5. Lastly, added a `mirrorCastleDestroyed` property to each item in `teamCastles` and update it to true in  `checkUnitCastleTalk` (new Lines 328-332) when a signal indicating a destroyed castle is found. Also check in `makeDecision` if this property is NOT true for your mirror castle - if it is true, does not build, which ensures that the "next" castle will take over building duties and start attacking its mirror castle.