### PR TITLE
Feature destroyer prophet and attacker prophet refactor

### DIFF
--- a/bots/psuteam7bot/combat.js
+++ b/bots/psuteam7bot/combat.js
@@ -4,6 +4,7 @@ import movement from "./movement.js";
 const combat = {};
 
 combat.UNITTYPE = ["CASTLE", "CHURCH", "PILGRIM", "CRUSADER", "PROPHET" , "PREACHER"]
+combat.TARGETPRIORITY = [0, 1, 5, 4, 3, 2]
 
 /**
  * Method to filter a list of robot elements (attackable, visible, etc.) by unit type

--- a/bots/psuteam7bot/prophet.js
+++ b/bots/psuteam7bot/prophet.js
@@ -75,6 +75,9 @@ prophet.doAction = (self) => {
     if(self.role === "ATTACKER")
         return prophet.takeAttackerAction(self);
 
+    if(self.role === "DESTROYER")
+        return prophet.takeDestroyerAction(self);
+
     //Should not fall through unless still UNASSIGNED or something horrible happened
     self.log('prophet ' + self.role + ' ' + self.me.id + ' still UNASSIGNED!!!')
     return;

--- a/bots/psuteam7bot/prophet.js
+++ b/bots/psuteam7bot/prophet.js
@@ -63,7 +63,7 @@ prophet.doAction = (self) => {
         else
         {
             self.log("Base defenders = " + JSON.stringify(nearbyDefenders.length) + ", Assigned as an attacker");
-            self.squadSize = 9; //-2, account for 1 defender and 1 trigger prophet, need to change squad detection if trigger prophet is to be part of squad
+            self.squadSize = 7; 
             self.role = "ATTACKER";
         }
     }
@@ -96,9 +96,8 @@ prophet.takeDefenderAction = (self) =>  {
         return self.attack(attacking.x - self.me.x, attacking.y - self.me.y);
     }
 
-
     //Limited movement towards enemy castle (movement towards guard post)
-    if(self.attackerMoves < 5)
+    if(self.attackerMoves < 3)
     {
         //Reusing attacker move naming convention
         self.attackerMoves++;

--- a/bots/psuteam7bot/prophet.js
+++ b/bots/psuteam7bot/prophet.js
@@ -287,21 +287,17 @@ prophet.fleeBehavior = (self, visibleRobots) => {
     }
 }
 
-//DEFENDER Behavior
-prophet.takeDefenderAction = (self) =>  {
+//Destroyer Behavior
+prophet.takeDestroyerAction = (self) =>  {
     self.log("DESTROYER prophet " + self.id + " taking turn");
-    //Use attacker moves to check whether 
-    if(self.target === null)
-    {     
-        self.target = self.potentialEnemyCastleLocation[0];
-    }
 
     const visibleRobots = self.getVisibleRobots();
     const attackable = combat.filterByAttackable(self, visibleRobots);
 
+    //Flee from enemies
     if(prophet.fleeBehavior(self, visibleRobots))
     {
-        return movement.moveAlongPath(self);
+       return movement.moveAlongPath(self);
     }
 
     //Attack visible enemies
@@ -310,6 +306,12 @@ prophet.takeDefenderAction = (self) =>  {
         let attacking = attackable[0];
         self.log("Attacking " + combat.UNITTYPE[attacking.unit] + " at " + attacking.x + ", " +  attacking.y);
         return self.attack(attacking.x - self.me.x, attacking.y - self.me.y);
+    }
+
+    if(movement.positionsAreEqual(self.target, self.me))
+    {
+        self.log('At target, Waiting...');
+        return;
     }
 
     //If no path yet
@@ -326,27 +328,8 @@ prophet.takeDefenderAction = (self) =>  {
         }
     }
 
-    if(self.squadSize === 0)
-    {
-        self.log('DESTROYER prophet ' + self.id + ' moving towards target, Current: [' + self.me.x + ',' + self.me.y + ']')
-        return movement.moveAlongPath(self);
-    }
-    
-
-    let squad = combat.filterByRange(visibleRobots, self.me, 0, 64);
-    squad = combat.filterByUnitType(squad, "PROPHET");
-
-    //Check if threshold is reached, then just move towards enemy base
-    if(squad.length >= self.squadSize) 
-    {
-        self.log('DESTROYER prophet ' + self.id + ' squad threshold reached! Moving to target')
-        self.squadSize = 0;
-
-        return;
-    }
-    //Should not fall through unless destroyer with squadSize threshold not reached yet
-    self.log('prophet ' + self.role + ' ' + self.me.id + ' doing nothing')
-    return;
+    self.log('DESTROYER prophet ' + self.id + ' moving towards target, Current: [' + self.me.x + ',' + self.me.y + ']')
+    return movement.moveAlongPath(self);
 }
 
 export default prophet;

--- a/projectUtils/psuteam7botCompiled.js
+++ b/projectUtils/psuteam7botCompiled.js
@@ -1082,6 +1082,7 @@ movement.hasFuelToMove = (self, target) => {
 const combat = {};
 
 combat.UNITTYPE = ["CASTLE", "CHURCH", "PILGRIM", "CRUSADER", "PROPHET" , "PREACHER"];
+combat.TARGETPRIORITY = [0, 1, 5, 4, 3, 2];
 
 /**
  * Method to filter a list of robot elements (attackable, visible, etc.) by unit type
@@ -1594,20 +1595,27 @@ prophet.doAction = (self) => {
         if(self.isRadioing(baseRobot))  //Check if base has broadcasted a signal on it's turn
         {
             //Get the message using baseRobot.signal and translate to position using helper function
-            self.potentialEnemyCastleLocation = [communication.signalToPosition(baseRobot.signal, self.map)];
-            self.potentialEnemyCastleLocation.push(movement.getDiagonalPatrolPosition(self.base, self.map));
+            self.target = communication.signalToPosition(baseRobot.signal, self.map);
         }
         else
         {
-            self.log("UNASSIGNED prophet didn't receive signal from base, using getAttackerPatrolRoute");
-            self.potentialEnemyCastleLocation = movement.getAttackerPatrolRoute(self.base, self.map);
+            self.log("UNASSIGNED prophet didn't receive signal from base, getting mirror coord");
+            self.target = movement.getMirrorCastle(self.me, self.map);
+        }
+
+        const {x, y} = self.target;
+        //If target is a resource depot, set role as destroyer
+        if(self.karbonite_map[y][x] || self.fuel_map[y][x])
+        {
+            self.log("Target is a resource depot, Assigned as a destroyer");
+            self.role = "DESTROYER";
+            return prophet.takeDestroyerAction(self);
         }
 
         const nearbyDefenders = self.getVisibleRobots().filter((robotElement) => {
             if(robotElement.team === self.me.team && robotElement.unit === self.me.unit)
             {
                 const distance = movement.getDistance(self.base, robotElement);
-                //30, assuming defender moved at max speed (r^2= 4) for 5 turns (4*5 = 20), + 10 to account for the possibility of prophet spawning in different starting tiles
                 return distance <= 64;
             }
         });
@@ -1622,7 +1630,7 @@ prophet.doAction = (self) => {
         else
         {
             self.log("Base defenders = " + JSON.stringify(nearbyDefenders.length) + ", Assigned as an attacker");
-            self.squadSize = 9; //-2, account for 1 defender and 1 trigger prophet, need to change squad detection if trigger prophet is to be part of squad
+            self.squadSize = 7; 
             self.role = "ATTACKER";
         }
     }
@@ -1632,6 +1640,9 @@ prophet.doAction = (self) => {
 
     if(self.role === "ATTACKER")
         return prophet.takeAttackerAction(self);
+
+    if(self.role === "DESTROYER")
+        return prophet.takeDestroyerAction(self);
 
     //Should not fall through unless still UNASSIGNED or something horrible happened
     self.log('prophet ' + self.role + ' ' + self.me.id + ' still UNASSIGNED!!!');
@@ -1652,15 +1663,14 @@ prophet.takeDefenderAction = (self) =>  {
         return self.attack(attacking.x - self.me.x, attacking.y - self.me.y);
     }
 
-
     //Limited movement towards enemy castle (movement towards guard post)
-    if(self.attackerMoves < 5)
+    if(self.attackerMoves < 3)
     {
         //Reusing attacker move naming convention
         self.attackerMoves++;
         if(self.path.length === 0)
         {
-            if(movement.aStarPathfinding(self, self.me, self.potentialEnemyCastleLocation[0], false)) {
+            if(movement.aStarPathfinding(self, self.me, self.target, false)) {
                 self.log(self.path);
             } else {
                 self.log('Cannot get path to guard post');
@@ -1682,24 +1692,16 @@ prophet.takeAttackerAction = (self) => {
     self.log("ATTACKER prophet " + self.id + " taking turn");
 
     //If no base
-    if(self.base == null)
+    if(self.base === null)
     {
         //Set opposite of current coord as target
-        self.potentialEnemyCastleLocation = movement.getAttackerPatrolRoute(self.me, self.map);
+        self.base = {x:-1, y:-1};
+        self.target = movement.getMirrorCastle(self.me, self.map);
     }
 
-
-    //If no target
-    if(self.potentialEnemyCastleLocation === null)
-    {
-        //Get potential enemy castle locations if Castle didn't send signal
-        self.potentialEnemyCastleLocation = movement.getAttackerPatrolRoute(self.base, self.map);
-    }
-
-    if(self.target === null)
-    {     
-        self.target = self.potentialEnemyCastleLocation[0];
-    }
+    //Checks for target update from base
+    communication.checkBaseSignalAndUpdateTarget(self);
+    communication.sendCastleTalkMessage(self);
 
     const visibleRobots = self.getVisibleRobots();
     const attackable = combat.filterByAttackable(self, visibleRobots);
@@ -1717,19 +1719,19 @@ prophet.takeAttackerAction = (self) => {
         return self.attack(attacking.x - self.me.x, attacking.y - self.me.y);
     }
 
-    //No enemy castle at target and there are more waypoint to check
-    if(self.potentialEnemyCastleLocation.length > 0 && movement.getDistance(self.me, self.target) <= 49)
+    //Still no target, and no update from base, do nothing
+    if(self.target === null)
     {
-        //Assign new target waypoint
-        self.potentialEnemyCastleLocation.shift();
-        if(self.potentialEnemyCastleLocation.length != 0) {
-            self.target = self.potentialEnemyCastleLocation[0];
-        }
+        self.log("No target, waiting for signal from base...");
+        return;
     }
 
-    //TODO No more patrol waypoint, do nothing
-    if(self.potentialEnemyCastleLocation.length === 0)
+    //If target is not enemy castle, report to team castles
+    if(communication.checkAndReportEnemyCastleDestruction(self))
     {
+        //Enemy castle destroyed, waiting for next order
+        self.log("Enemy castle destroyed, message stored");
+        self.target = null;
         return;
     }
 
@@ -1843,6 +1845,51 @@ prophet.fleeBehavior = (self, visibleRobots) => {
     } else {
         return false;
     }
+};
+
+//Destroyer Behavior
+prophet.takeDestroyerAction = (self) =>  {
+    self.log("DESTROYER prophet " + self.id + " taking turn");
+
+    const visibleRobots = self.getVisibleRobots();
+    const attackable = combat.filterByAttackable(self, visibleRobots);
+
+    //Flee from enemies
+    if(prophet.fleeBehavior(self, visibleRobots))
+    {
+       return movement.moveAlongPath(self);
+    }
+
+    //Attack visible enemies
+    if(attackable.length > 0)
+    {
+        let attacking = attackable[0];
+        self.log("Attacking " + combat.UNITTYPE[attacking.unit] + " at " + attacking.x + ", " +  attacking.y);
+        return self.attack(attacking.x - self.me.x, attacking.y - self.me.y);
+    }
+
+    if(movement.positionsAreEqual(self.target, self.me))
+    {
+        self.log('At target, Waiting...');
+        return;
+    }
+
+    //If no path yet
+    if(self.path.length === 0)
+    {
+        if(movement.aStarPathfinding(self, self.me, self.target, false)) 
+        {
+            self.log(self.path);
+        } 
+        else 
+        {
+            self.log('Cannot get path to position');
+            return;
+        }
+    }
+
+    self.log('DESTROYER prophet ' + self.id + ' moving towards target, Current: [' + self.me.x + ',' + self.me.y + ']');
+    return movement.moveAlongPath(self);
 };
 
 const castle = {};


### PR DESCRIPTION
More straightforward than I thought,

`Prophet.js`
- Added DESTROYER role and behavior to prophet
- Added Unassigned prophet changing to DESTROYER if `self.target` is a karbonite/ fuel depot
- Changed Unassigned prophet to use communication from Castle as `self.target`
- Refactored (updated) ATTACKER prophet to be similar to ATTACKER crusader, able to communicate with Castles
- Refactored DEFENDER prophet to use `self.target` and perform slight movement so that newly created prophets can properly detect the number of DEFENDERS near the base after they're spawned and get assigned roles properly