### PR TITLE
Macro and pilgrim churchbuilding

### DIFF
--- a/bots/psuteam7bot/castle.js
+++ b/bots/psuteam7bot/castle.js
@@ -310,6 +310,9 @@ castle.makeDecision = (self, otherCastles, hasSignalToSend) => {
         return castle.findUnitPlace(self, 'PROPHET');
     }
 
+    //Check if more pilgrims are needed - won't be built until next turn
+    castle.assessLocalPilgrims(self);
+
     const nearbyDefenders = self.getVisibleRobots().filter((robotElement) => {
         if(robotElement.team === self.me.team && robotElement.unit === 4)
         {
@@ -318,22 +321,16 @@ castle.makeDecision = (self, otherCastles, hasSignalToSend) => {
         }
     });
 
-    //Add defenders to front of queue if needed
     if(nearbyDefenders.length < self.macro.defenders) {
         self.log("LESS DEFENDERS: " + nearbyDefenders.length)
-        let needToAdd = self.macro.defenders;
-        self.castleBuildQueue.forEach(bot => {
-            if(bot.unit === "PROPHET") {
-                needToAdd--;
-            }
-        })
-        for(let i = 0; i < needToAdd; i++) {
-            self.castleBuildQueue.unshift({unit: "PROPHET", x: self.target.x, y: self.target.y});
+        if(self.fuel >= SPECS.UNITS[SPECS["PROPHET"]].CONSTRUCTION_FUEL && 
+            self.karbonite >= SPECS.UNITS[SPECS["PROPHET"]].CONSTRUCTION_KARBONITE) {
+            //Signal what you would normally             
+            const ctSignal = self.teamCastles[0].signalBuilding ? 100 : 101;
+            self.castleTalk(ctSignal);
+            return castle.findUnitPlace(self, "PROPHET");
         }
     }   
-
-    //Check if more pilgrims are needed and add to front of queue if so
-    castle.assessLocalPilgrims(self);
 
     //otherwise castles will signal which castle has done building the units and will take decisions accordingly
     const checkSignal = otherCastles.findIndex(castle =>{

--- a/bots/psuteam7bot/castle.js
+++ b/bots/psuteam7bot/castle.js
@@ -633,8 +633,8 @@ castle.assessLocalPilgrims = (self) => {
 
     //If some pilgrims missing, do work to replenish local pilgrim count
     if(currentLocal.length < self.macro.localPilgrims) {
-        const depots = movement.getResourcesInRange(self.me, 16, self.karbonite_map).concat(movement.getResourcesInRange(self.me, 16, self.fuel_map));
-        depots.filter(d => {
+        let depots = movement.getResourcesInRange(self.me, 16, self.karbonite_map).concat(movement.getResourcesInRange(self.me, 16, self.fuel_map));
+        depots = depots.filter(d => {
             let occupied = false;
             currentLocal.forEach(bot => {
                 if(movement.positionsAreEqual(bot, d)) {

--- a/bots/psuteam7bot/castle.js
+++ b/bots/psuteam7bot/castle.js
@@ -20,11 +20,11 @@ castle.doAction = (self) => {
         const competitionDepots = castle.findDepotClusters(self, 3, 0.7, true);
         const churchDepots = castle.findDepotClusters(self, 3, 0.7, false);
         const extraUnitArray = [];
-        churchDepots.forEach(depot => {
-            extraUnitArray.push({unit: "PILGRIM", x: depot.x, y: depot.y});
-        })
         competitionDepots.forEach(depot => {
             extraUnitArray.push({unit: "PROPHET", x: depot.x, y: depot.y});
+        })
+        churchDepots.forEach(depot => {
+            extraUnitArray.push({unit: "PILGRIM", x: depot.x, y: depot.y});
         })
         self.castleBuildQueue = extraUnitArray.concat(self.castleBuildQueue);
         self.log("ADDING SPECIAL UNITS TO QUEUE");
@@ -74,10 +74,11 @@ castle.doAction = (self) => {
         if(botsInQueue > 0 && ((self.castleBuildQueue[0].unit == "PILGRIM") || (self.castleBuildQueue[0].unit == "PROPHET"))) {
             return castle.buildFromQueue(self);
         //Keep queue at reasonable size, adding another prophet as necessary so prophets are continually build
-        } else if (botsInQueue <= 5) {
+        }/* else if (botsInQueue <= 5) {
             self.castleBuildQueue.push({unit: "CRUSADER", x: self.target.x, y: self.target.y});
         }
-        return castle.makeDecision(self, self.teamCastles, hasSignalToSend);
+        return castle.makeDecision(self, self.teamCastles, hasSignalToSend);*/
+        return;
     }
 }
 
@@ -518,10 +519,16 @@ castle.findDepotClusters = (self, minClusterSize, competitionIndex, searchAggres
             } else if (clusters[nearby].count < clusters[i].count) {
                 clusters.splice(nearby, 1);
             } else {
-                if(movement.getDistance(self.me, clusters[i]) > movement.getDistance(self.me, clusters[nearby])) {
+                if(clusters[nearby].dist < clusters[i].dist) {
                     clusters.splice(i, 1);
-                } else {
+                } else if(clusters[nearby].dist > clusters[i].dist) {
                     clusters.splice(nearby, 1);
+                } else {
+                    if(movement.getDistance(self.me, clusters[i]) > movement.getDistance(self.me, clusters[nearby])) {
+                        clusters.splice(i, 1);
+                    } else {
+                        clusters.splice(nearby, 1);
+                    }
                 }
             }
             nearby = clusters.findIndex(c => {

--- a/bots/psuteam7bot/castle.js
+++ b/bots/psuteam7bot/castle.js
@@ -383,7 +383,7 @@ castle.makeDecision = (self, otherCastles, hasSignalToSend) => {
         self.log("Castle talk received: " + alliedUnits[i].castle_talk);
         //self.log("Enemy castles: ");
         //self.log(self.enemyCastles);
-        let messageValue = alliedUnits[i].castle_talk;
+        let messageValue = alliedUnits[i].castle_talk -1;
         
         //Castle talk is in the range 0-63 inclusive, reserved for coords - assume as destroyed enemy castle loc
         if(messageValue >= 0 && messageValue < 64)

--- a/bots/psuteam7bot/castle.js
+++ b/bots/psuteam7bot/castle.js
@@ -310,9 +310,6 @@ castle.makeDecision = (self, otherCastles, hasSignalToSend) => {
         return castle.findUnitPlace(self, 'PROPHET');
     }
 
-    //Check if more pilgrims are needed - won't be built until next turn
-    castle.assessLocalPilgrims(self);
-
     const nearbyDefenders = self.getVisibleRobots().filter((robotElement) => {
         if(robotElement.team === self.me.team && robotElement.unit === 4)
         {
@@ -321,16 +318,22 @@ castle.makeDecision = (self, otherCastles, hasSignalToSend) => {
         }
     });
 
+    //Add defenders to front of queue if needed
     if(nearbyDefenders.length < self.macro.defenders) {
         self.log("LESS DEFENDERS: " + nearbyDefenders.length)
-        if(self.fuel >= SPECS.UNITS[SPECS["PROPHET"]].CONSTRUCTION_FUEL && 
-            self.karbonite >= SPECS.UNITS[SPECS["PROPHET"]].CONSTRUCTION_KARBONITE) {
-            //Signal what you would normally             
-            const ctSignal = self.teamCastles[0].signalBuilding ? 100 : 101;
-            self.castleTalk(ctSignal);
-            return castle.findUnitPlace(self, "PROPHET");
+        let needToAdd = self.macro.defenders;
+        self.castleBuildQueue.forEach(bot => {
+            if(bot.unit === "PROPHET") {
+                needToAdd--;
+            }
+        })
+        for(let i = 0; i < needToAdd; i++) {
+            self.castleBuildQueue.unshift({unit: "PROPHET", x: self.target.x, y: self.target.y});
         }
     }   
+
+    //Check if more pilgrims are needed and add to front of queue if so
+    castle.assessLocalPilgrims(self);
 
     //otherwise castles will signal which castle has done building the units and will take decisions accordingly
     const checkSignal = otherCastles.findIndex(castle =>{

--- a/bots/psuteam7bot/castle.js
+++ b/bots/psuteam7bot/castle.js
@@ -17,7 +17,7 @@ castle.doAction = (self) => {
         self.enemyCastles = movement.getEnemyCastleLocations(self.teamCastles, self.map);
         self.log("Enemy castles: ");
         self.log(self.enemyCastles);
-        const competitionDepots = castle.findDepotClusters(self, 3, 0.7, true);
+        /*const competitionDepots = castle.findDepotClusters(self, 3, 0.7, true);
         const churchDepots = castle.findDepotClusters(self, 3, 0.7, false);
         const extraUnitArray = [];
         competitionDepots.forEach(depot => {
@@ -28,7 +28,7 @@ castle.doAction = (self) => {
         })
         self.castleBuildQueue = extraUnitArray.concat(self.castleBuildQueue);
         self.log("ADDING SPECIAL UNITS TO QUEUE");
-        self.log(self.castleBuildQueue);
+        self.log(self.castleBuildQueue);*/
     }
 
     //On first turn:
@@ -81,6 +81,37 @@ castle.doAction = (self) => {
     }
 }
 
+
+castle.makeMacroDecisions = (self) => {
+    const castleCount = self.teamCastles.length;
+    const castleDistances = [];
+    self.teamCastles.forEach(tc => {
+        castleDistances.push(movement.getDistance(tc, movement.getMirrorCastle(tc, self.map)));
+    });
+    const competitionDepots = castle.findDepotClusters(self, 3, 0.7, true);
+    const churchDepots = castle.findDepotClusters(self, 3, 0.7, false);
+
+    if(castleCount === 1) {
+        if(castleDistances[0] > 18) {
+            self.macro.defenders = 0;
+            self.macro.buildChurch = false;
+            self.macro.turtle = false;
+        } else {
+            self.macro.defenders = 8;
+            self.macro.turtle = true;
+            self.macro.buildChurch = churchDepots.length > 0;
+            self.macro.considerChurchTurn = 50;
+        }
+    } else {
+        self.macro.defenders = 3;
+        self.macro.turtle = false;
+        self.macro.defenders = 8;
+        self.macro.buildChurch = churchDepots.length > 0;
+    }
+
+}
+
+
 /** Method to check if any of the adjacent tile is available. Place the unit if true.
  */
 castle.findUnitPlace = (self, unitType) => {
@@ -110,6 +141,7 @@ castle.buildFromQueue = (self) => {
     const botsOnMap = combat.getVisibleAllies(self).length;
     let buildCount = 0  
     let fuelCap = 0 
+    let karbCap = 0;
     if(self.me.turn > 20) {
         /*Take lesser of 1. bots built and 2. bots on map
           1. Case for when castle destroyed and new one starts building - ensures it starts sooner rather than when 
@@ -119,10 +151,11 @@ castle.buildFromQueue = (self) => {
         */
         buildCount = Math.min(self.teamCastles[0].buildCounter.total, botsOnMap);
         fuelCap = 50+5*buildCount; //25+25*self.teamCastles.length;
+        karbCap = 20*self.teamCastles.length;
     }
     //If past very start of game and fuel amount low, don't build a unit
-    if(self.fuel < fuelCap) {
-        self.log('not building unit to conserve fuel');
+    if(self.fuel < fuelCap || self.karbonite < karbCap) {
+        self.log('not building unit to conserve resources');
         return;
     //If you are able to build next unit, signal coordinates so it knows where to go and build it
     } else if(self.fuel >= SPECS.UNITS[SPECS[nextBuild.unit]].CONSTRUCTION_FUEL && 
@@ -278,6 +311,26 @@ castle.makeDecision = (self, otherCastles, hasSignalToSend) => {
         self.log('Enemies in the visible range, building phrophets');
         return castle.findUnitPlace(self, 'PROPHET');
     }
+
+    const nearbyDefenders = self.getVisibleRobots().filter((robotElement) => {
+        if(robotElement.team === self.me.team && robotElement.unit === 4)
+        {
+            const distance = movement.getDistance(self.me, robotElement);
+            return distance <= 64;
+        }
+    });
+
+    if(nearbyDefenders.length < self.macro.defenders) {
+        self.log("LESS DEFENDERS: " + nearbyDefenders.length)
+        if(self.fuel >= SPECS.UNITS[SPECS["PROPHET"]].CONSTRUCTION_FUEL && 
+            self.karbonite >= SPECS.UNITS[SPECS["PROPHET"]].CONSTRUCTION_KARBONITE) {
+            //Signal what you would normally             
+            const ctSignal = self.teamCastles[0].signalBuilding ? 101 : 100;
+            self.castleTalk(ctSignal);
+            return castle.findUnitPlace(self, "PROPHET");
+        }
+    }
+   
 
     //otherwise castles will signal which castle has done building the units and will take decisions accordingly
     const checkSignal = otherCastles.findIndex(castle =>{

--- a/bots/psuteam7bot/castle.js
+++ b/bots/psuteam7bot/castle.js
@@ -18,11 +18,16 @@ castle.doAction = (self) => {
         self.log("Enemy castles: ");
         self.log(self.enemyCastles);
         const competitionDepots = castle.findDepotClusters(self, 3, 0.7, true);
-        const prophetArray = []
-        competitionDepots.forEach(depot => {
-            prophetArray.push({unit: "PROPHET", x: depot.x, y: depot.y});
+        const churchDepots = castle.findDepotClusters(self, 3, 0.7, false);
+        const extraUnitArray = [];
+        churchDepots.forEach(depot => {
+            extraUnitArray.push({unit: "PILGRIM", x: depot.x, y: depot.y});
         })
-        self.castleBuildQueue = prophetArray.concat(self.castleBuildQueue);
+        competitionDepots.forEach(depot => {
+            extraUnitArray.push({unit: "PROPHET", x: depot.x, y: depot.y});
+        })
+        self.castleBuildQueue = extraUnitArray.concat(self.castleBuildQueue);
+        self.log("ADDING SPECIAL UNITS TO QUEUE");
         self.log(self.castleBuildQueue);
     }
 

--- a/bots/psuteam7bot/castle.js
+++ b/bots/psuteam7bot/castle.js
@@ -74,11 +74,10 @@ castle.doAction = (self) => {
         if(botsInQueue > 0 && ((self.castleBuildQueue[0].unit == "PILGRIM") || (self.castleBuildQueue[0].unit == "PROPHET"))) {
             return castle.buildFromQueue(self);
         //Keep queue at reasonable size, adding another prophet as necessary so prophets are continually build
-        }/* else if (botsInQueue <= 5) {
+        } else if (botsInQueue <= 5) {
             self.castleBuildQueue.push({unit: "CRUSADER", x: self.target.x, y: self.target.y});
         }
-        return castle.makeDecision(self, self.teamCastles, hasSignalToSend);*/
-        return;
+        return castle.makeDecision(self, self.teamCastles, hasSignalToSend);
     }
 }
 

--- a/bots/psuteam7bot/communication.js
+++ b/bots/psuteam7bot/communication.js
@@ -71,8 +71,8 @@ communication.checkAndReportEnemyCastleDestruction = (self) => {
     if(robotID === 0)
     {
         //Add coords to pending messages, push y then x
-        self.pendingMessages.push(y);
-        self.pendingMessages.push(x);
+        self.pendingMessages.push(y+1);
+        self.pendingMessages.push(x+1);
         return true;
     }
     else //Case target occupied or not in visible radius, -1 or there is a robotID > 0
@@ -81,8 +81,8 @@ communication.checkAndReportEnemyCastleDestruction = (self) => {
         if(robotID > 0 && self.getRobot(robotID).unit !== 0)
         {
             //Add coords to pending messages, push y then x
-            self.pendingMessages.push(y);
-            self.pendingMessages.push(x);
+            self.pendingMessages.push(y+1);
+            self.pendingMessages.push(x+1);
             return true;
         }
     }

--- a/bots/psuteam7bot/crusader.js
+++ b/bots/psuteam7bot/crusader.js
@@ -105,8 +105,9 @@ crusader.takeAttackerAction = (self) => {
         }
     }
 
+    const movesFromBase = Math.floor(Math.sqrt(movement.getDistance(self.base, self.target))/6)-1;
     //If first seven turns, move away from allied base towards enemy base, else check if squadSize threshold is met and is 0
-    if(self.attackerMoves < 6)
+    if(self.attackerMoves < movesFromBase)
     {
         if(movement.hasFuelToMove(self, self.path[self.path.length-1])) {
             self.attackerMoves++;

--- a/bots/psuteam7bot/pilgrim.js
+++ b/bots/psuteam7bot/pilgrim.js
@@ -24,7 +24,7 @@ pilgrim.doAction = (self) => {
         //Set target base on castle signal
         const {x, y} = communication.signalToPosition(self.getRobot(self.teamCastles[0].id).signal, self.map)
         self.target = {x: x, y: y};
-        self.log("pilgrim MINER " + self.id + " targeting depot at [" + self.target.x + "," + self.target.y + "]")
+        self.log("pilgrim PIONEER " + self.id + " targeting depot at [" + self.target.x + "," + self.target.y + "]")
     }
 
     if(self.role === 'MINER') {
@@ -239,7 +239,7 @@ pilgrim.updateResourceTarget = (self) => {
 pilgrim.buildChurch = (self) => {
     let bestCount = 0;
     let bestDist = 0;
-    let bestLoc;
+    let bestLoc = null;
     for(let i = -1; i<= 1; i++) {   
         for(let j = -1; j<= 1; j++) {
             const loc = {x: (self.me.x + i), y: (self.me.y+j)} 
@@ -259,9 +259,14 @@ pilgrim.buildChurch = (self) => {
             }
         }
     }
-    self.base = {x: bestLoc.x, y: bestLoc.y}
-    self.log('pilgrim ' + self.id + ' building a church at [' + bestLoc.x + ',' + bestLoc.y +']'); 
-    return self.buildUnit(1, bestLoc.dx, bestLoc.dy); 
+    if (bestLoc != null) {
+        self.base = {x: bestLoc.x, y: bestLoc.y}
+        self.log('pilgrim ' + self.id + ' building a church at [' + bestLoc.x + ',' + bestLoc.y +']'); 
+        return self.buildUnit(1, bestLoc.dx, bestLoc.dy); 
+    } else {
+        self.log("No viable church positions - no taking action");
+        return;
+    }
 }
 
 

--- a/bots/psuteam7bot/pilgrim.js
+++ b/bots/psuteam7bot/pilgrim.js
@@ -12,17 +12,13 @@ pilgrim.maxFuel = SPECS.UNITS[SPECS.PILGRIM].FUEL_CAPACITY;
  */
 pilgrim.doAction = (self) => {
     self.log("pilgrim " + self.id + " taking turn - occupied depots: " + JSON.stringify(self.occupiedResources));
-    const onMap = (self, x, y) => {
-        const mapSize = self.map.length;
-        return (x < mapSize) && (x >= 0) && (y < mapSize) && (y >= 0)
-    }
     
     if (self.role === 'UNASSIGNED') {
         self.base = movement.findAdjacentBase(self);
-        //Tweaking to set base not directly on top of castle, because causing pathfinding issues
-        //self.base = {x: self.me.x, y: self.me.y};
+        if(self.base === null) {
+            self.base = {x: self.me.x, y: self.me.y};
+        }
         self.log("Set base as " + JSON.stringify(self.base));
-        //Gets nearby base, checks turn
         self.role = 'PIONEER'
         communication.initTeamCastleInformation(self);
         //Set target base on castle signal

--- a/bots/psuteam7bot/pilgrim.js
+++ b/bots/psuteam7bot/pilgrim.js
@@ -238,6 +238,7 @@ pilgrim.updateResourceTarget = (self) => {
  */
 pilgrim.buildChurch = (self) => {
     let bestCount = 0;
+    let bestDist = 0;
     let bestLoc;
     for(let i = -1; i<= 1; i++) {   
         for(let j = -1; j<= 1; j++) {
@@ -249,15 +250,17 @@ pilgrim.buildChurch = (self) => {
             const locInfo = castle.processLocalDepots(self, loc);
             if(locInfo.count > bestCount) {
                 bestCount = locInfo.count;
+                bestDist = locInfo.dist;
                 bestLoc = {x: loc.x, y: loc.y, dx: i, dy: j};
-            } else if (locInfo.count === bestCount && (movement.getDistance(self.base, bestLoc) > movement.getDistance(self.base, loc))) {
+            } else if (locInfo.count === bestCount && bestDist > locInfo.dist) {
                 bestCount = locInfo.count;
+                bestDist = locInfo.dist;
                 bestLoc = {x: loc.x, y: loc.y, dx: i, dy: j};
             }
         }
     }
     self.base = {x: bestLoc.x, y: bestLoc.y}
-    self.log('pilgrim ' + self.id + ' building a church at [' + (self.me.x+i) + ',' + (self.me.y+j) +']'); 
+    self.log('pilgrim ' + self.id + ' building a church at [' + bestLoc.x + ',' + bestLoc.y +']'); 
     return self.buildUnit(1, bestLoc.dx, bestLoc.dy); 
 }
 

--- a/bots/psuteam7bot/pilgrim.js
+++ b/bots/psuteam7bot/pilgrim.js
@@ -113,6 +113,9 @@ pilgrim.takePioneerAction = (self) => {
         const localBases = self.getVisibleRobots().filter(bot => {
             return bot.team === self.me.team && bot.unit <= 1 && movement.getDistance(self.me, bot) <= 49;
         });
+        localBases.sort((a,b) => {
+            return movement.getDistance(self.me, b) - movement.getDistance(self.me, a);
+        });
         //If nothing around, assume it should be a church-builder
         if(localBases.length === 0) {
             //Build church if you can
@@ -124,6 +127,7 @@ pilgrim.takePioneerAction = (self) => {
                 return self.mine();
             }
         } else {
+            self.base = {x: localBases[0].x, y: localBases[0].y};
             self.role = 'MINER';
             self.log('pilgrim PIONEER ' + self.id + ' becoming MINER')
             return pilgrim.takeMinerAction(self);

--- a/bots/psuteam7bot/prophet.js
+++ b/bots/psuteam7bot/prophet.js
@@ -53,12 +53,23 @@ prophet.doAction = (self) => {
             }
         });
 
-        //2 defenders towards mirror castle, should be enough to kill a crusader in 2 turns before it gets to attack range
-        if(nearbyDefenders.length < 3)
+        //Defenders towards mirror castle, should be enough to kill a crusader in 2 turns before it gets to attack range
+        if(nearbyDefenders.length < 9)
         {
             self.log("Base defenders = " + JSON.stringify(nearbyDefenders.length) + ", Assigned as a defender");
             self.role = "DEFENDER";
-
+            const defendDirection = movement.getRelativeDirection(self.me, self.target)
+            let defendDirIndex = movement.getDirectionIndex(defendDirection);
+            let dirs = movement.getDirectionsBetween(defendDirIndex, 1, 1).sort((a,b) => {
+                return movement.getDistance(b, defendDirection) - movement.getDistance(a, defendDirection);
+            });
+            //Choose a direction
+            let targetDir = dirs[nearbyDefenders.length % 3];
+            const dist = Math.abs(targetDir.x)+Math.abs(targetDir.y) === 2 ? 3 : 5
+            let t = {x: self.me.x+dist*targetDir.x, y: self.me.y+dist*targetDir.y}
+            //Edge case where target not on map
+            t = self._bc_check_on_map(t.x, t.y) ? t : {x: self.me.x+5*defendDirection.x, y: self.me.y+5*defendDirection.y}
+            self.target = t;
         }
         else
         {
@@ -99,11 +110,13 @@ prophet.takeDefenderAction = (self) =>  {
     //Limited movement towards enemy castle (movement towards guard post)
     if(self.attackerMoves < 3)
     {
+        self.log("IN ATTACKER MOVES")
+        self.log(JSON.stringify(self.target));
         //Reusing attacker move naming convention
         self.attackerMoves++;
         if(self.path.length === 0)
         {
-            if(movement.aStarPathfinding(self, self.me, self.target, false)) {
+            if(movement.aStarPathfinding(self, self.me, self.target, true)) {
                 self.log(self.path)
             } else {
                 self.log('Cannot get path to guard post')

--- a/bots/psuteam7bot/prophet.js
+++ b/bots/psuteam7bot/prophet.js
@@ -303,8 +303,19 @@ prophet.takeDestroyerAction = (self) =>  {
 
     if(movement.positionsAreEqual(self.target, self.me))
     {
-        self.log('At target, Waiting...');
-        return;
+        //Check there is a pilgrim trying to get to this target depot
+        const nearbyPilgrims = self.getVisibleRobots().filter(bot => {
+            return bot.team === self.me.team && bot.unit === 2 && movement.getDistance(self.me, bot) <= 2;
+        })
+        //If not, just wait
+        if(nearbyPilgrims.length === 0) {
+            self.log('At target, Waiting...');
+            return;
+        //If pilgrim wants spot, change target to somewhere else and move off depot for them
+        } else {
+            self.log("CHANGING TARGET SO PILGRIM CAN MINE/BUILD A CHURCH");
+            self.target = movement.findNearestLocation(self, self.me);
+        }
     }
 
     //If no path yet

--- a/bots/psuteam7bot/prophet.js
+++ b/bots/psuteam7bot/prophet.js
@@ -318,6 +318,15 @@ prophet.takeDestroyerAction = (self) =>  {
         }
     }
 
+    //Check for edge case where pilgrim on target, in which case adjust target
+    if(self.path.length === 1) {
+        const botId = self.getVisibleRobotMap()[self.target.y][self.target.x];
+        if(botId > 0 && (self.getRobot(botId).unit === 2 && self.getRobot(botId).team === self.me.team)) {
+            self.log("CHANGING TARGET BECAUSE PILGRIM MINING/BUILDING A CHURCH ON TARGET");
+            self.target = movement.findNearestLocation(self, self.me);
+            self.path = []
+        }
+    }
     //If no path yet
     if(self.path.length === 0)
     {

--- a/bots/psuteam7bot/robot.js
+++ b/bots/psuteam7bot/robot.js
@@ -30,6 +30,12 @@ class MyRobot extends BCAbstractRobot {
         this.baseID = null;                              //ID of original castle/church robot
         this.pendingMessages = [];                       //Stores castle signal to units for new targets
         this.receivedMessages = [];                      //Store partially received castle talk signal
+        this.macro = {
+            defenders: 2,
+            buildChurch: false,
+            considerChurchTurn: 1000,
+            turtle: false      
+        }
     }
     turn() {
         if(this.previous == null) {

--- a/bots/psuteam7bot/robot.js
+++ b/bots/psuteam7bot/robot.js
@@ -31,6 +31,7 @@ class MyRobot extends BCAbstractRobot {
         this.pendingMessages = [];                       //Stores castle signal to units for new targets
         this.receivedMessages = [];                      //Store partially received castle talk signal
         this.macro = {
+            localPilgrims: 0,
             defenders: 2,
             buildChurch: false,
             considerChurchTurn: 1000,

--- a/projectUtils/psuteam7botCompiled.js
+++ b/projectUtils/psuteam7botCompiled.js
@@ -1359,6 +1359,569 @@ communication.checkBaseSignalAndUpdateTarget = (self) => {
     return false;
 };
 
+const castle = {};
+
+
+castle.doAction = (self) => {
+
+    self.log("castle" + self.id + "taking turn.");
+  
+    castle.recordPosition(self);
+    castle.findPosition(self);
+    if(self.me.turn === 5)
+    {
+        self.enemyCastles = movement.getEnemyCastleLocations(self.teamCastles, self.map);
+        self.log("Enemy castles: ");
+        self.log(self.enemyCastles);
+        const competitionDepots = castle.findDepotClusters(self, 3, 0.7, true);
+        const churchDepots = castle.findDepotClusters(self, 3, 0.7, false);
+        const extraUnitArray = [];
+        competitionDepots.forEach(depot => {
+            extraUnitArray.push({unit: "PROPHET", x: depot.x, y: depot.y});
+        });
+        churchDepots.forEach(depot => {
+            extraUnitArray.push({unit: "PILGRIM", x: depot.x, y: depot.y});
+        });
+        self.castleBuildQueue = extraUnitArray.concat(self.castleBuildQueue);
+        self.log("ADDING SPECIAL UNITS TO QUEUE");
+        self.log(self.castleBuildQueue);
+    }
+
+    //On first turn:
+    //  1. add to castleBuildQueue with pilgrims for each local karbonite depot
+    //  2. add to castleBuildQueue with pilgrims for each local fuel depot
+    //  3. add to castleBuildQueue a single crusader targeting the mirror castle.
+    //This ensures that all local depots are filled and a crusader will be built after
+    if(self.me.turn === 1)
+    {
+        
+        const karboniteDepots = movement.getResourcesInRange(self.me, 16, self.karbonite_map);
+        karboniteDepots.forEach(depot => {
+            self.castleBuildQueue.push({unit: "PILGRIM", x: depot.x, y: depot.y});
+        });
+
+        const fuelDepots = movement.getResourcesInRange(self.me, 16, self.fuel_map);
+        fuelDepots.forEach(depot => {
+            self.castleBuildQueue.push({unit: "PILGRIM", x: depot.x, y: depot.y});
+        });
+        
+        const mirrorCastle = movement.getMirrorCastle(self.me, self.map);
+        self.target = mirrorCastle;
+        self.log(self.castleBuildQueue);
+        return castle.buildFromQueue(self);
+    }
+    else if (self.me.turn <= 4) 
+    {
+        self.log("BUILD QUEUE NON-EMPTY");
+        self.log(self.castleBuildQueue);
+        const botsInQueue = self.castleBuildQueue.length;
+        //Keep queue at reasonable size, adding another crusader as necessary so crusaders are continually build
+        if (botsInQueue <= 5) {
+            self.castleBuildQueue.push({unit: "CRUSADER", x: self.target.x, y: self.target.y});
+        }
+        return castle.buildFromQueue(self);
+    }
+    else 
+    {
+        castle.checkUnitCastleTalk(self);
+        const hasSignalToSend = castle.signalNewUnitTarget(self);
+        const botsInQueue = self.castleBuildQueue.length;
+        //If there are still pilgrims of prophets to build, prioritize those unique units
+        if(botsInQueue > 0 && ((self.castleBuildQueue[0].unit == "PILGRIM") || (self.castleBuildQueue[0].unit == "PROPHET"))) {
+            return castle.buildFromQueue(self);
+        //Keep queue at reasonable size, adding another prophet as necessary so prophets are continually build
+        } else if (botsInQueue <= 5) {
+            self.castleBuildQueue.push({unit: "CRUSADER", x: self.target.x, y: self.target.y});
+        }
+        return castle.makeDecision(self, self.teamCastles, hasSignalToSend);
+    }
+};
+
+/** Method to check if any of the adjacent tile is available. Place the unit if true.
+ */
+castle.findUnitPlace = (self, unitType) => {
+    for(let i = -1; i<= 1; i++){   
+        for(let j = -1; j<= 1; j++){
+            const location = {x: (self.me.x + i), y: (self.me.y +j)}; 
+            if(movement.isPassable(location, self.map, self.getVisibleRobotMap()))
+            {
+                //Send signal starting at turn 3 so you don't overrride location communication at start
+                /*if(self.me.turn > 4) {
+                    self.castleTalk(SPECS[unitType]);
+                }*/
+
+                self.log('castle ' + self.id + ' building unit ' + unitType + ' at [' + (self.me.x+i) + ',' + (self.me.y+j) +']'); 
+                return self.buildUnit(SPECS[unitType], i, j);       
+            }
+        }
+    }
+    return;
+};
+
+/**
+ * Method to build next unit pushed on `castleBuildQueue`. Currently no checks that should be implemented
+ */
+castle.buildFromQueue = (self) => {
+    const nextBuild = self.castleBuildQueue[0];
+    const botsOnMap = combat.getVisibleAllies(self).length;
+    let buildCount = 0;  
+    let fuelCap = 0; 
+    if(self.me.turn > 20) {
+        /*Take lesser of 1. bots built and 2. bots on map
+          1. Case for when castle destroyed and new one starts building - ensures it starts sooner rather than when 
+             bots at destroyed castle eventually eliminated
+          2. Case for when you've built a lot but bots keep getting destroyed - ensures that you don't stop building
+             if you need more on the map
+        */
+        buildCount = Math.min(self.teamCastles[0].buildCounter.total, botsOnMap);
+        fuelCap = 50+5*buildCount; //25+25*self.teamCastles.length;
+    }
+    //If past very start of game and fuel amount low, don't build a unit
+    if(self.fuel < fuelCap) {
+        self.log('not building unit to conserve fuel');
+        return;
+    //If you are able to build next unit, signal coordinates so it knows where to go and build it
+    } else if(self.fuel >= SPECS.UNITS[SPECS[nextBuild.unit]].CONSTRUCTION_FUEL && 
+       self.karbonite >= SPECS.UNITS[SPECS[nextBuild.unit]].CONSTRUCTION_KARBONITE) {
+        self.castleBuildQueue.shift();
+        self.signal(communication.positionToSignal(nextBuild, self.map), 2);
+        return castle.findUnitPlace(self, nextBuild.unit);
+    } else {
+        self.log('cannot build unit ' + nextBuild.unit + '- not enough resources');
+        return;
+    }
+};
+
+/** Each castle will try to locate and record the positions of the friendly castles at the start of the game
+ * Input: self = this is the reference to the object to the calling method. 
+ * Output: returnPosition = return value containing the positions of the friendly castle       
+ *  */
+castle.recordPosition = (self) => {
+    let turn = self.me.turn;
+    if(turn <= 2){
+        self.castleTalk(self.me.x);
+    }
+    else if(turn <= 4){
+        self.castleTalk(self.me.y);
+    }
+};
+
+/**Find positions of the friendly castles. 
+ * Input: self, this is the reference to the object to the calling method.
+ * Output: positions of other friendly castles.
+ */
+castle.findPosition = (self) => {
+    //Filter by those that have a castle talk, since apparently unit does not appear if not in vision radius
+    const bots = self.getVisibleRobots().filter(bot =>{
+        return bot.team === self.me.team && bot.castle_talk > 0;
+    });
+    let turn = self.me.turn;
+    const buildCounter = {
+        pilgrims:0,
+        crusader:0,
+        prophet:0,
+        total:0
+    };
+    const maxDist = -2*Math.pow(self.map.length, 2)-1;
+
+    bots.forEach(foundCastle => {
+        const addedToTeamCastles = self.teamCastles.findIndex(c => {
+            return c.id === foundCastle.id;
+        });
+        //Init an item in teamCastles if not already in teamCastles for initial turns
+        if (addedToTeamCastles < 0 && turn < 5) {
+            self.teamCastles.push({
+                id: foundCastle.id,
+                x: 0, 
+                y: 0, 
+                buildCounter: buildCounter, 
+                signalBuilding: false,
+                mirrorCastleDestroyed: false,
+                silentCount: 0
+            });
+        }
+
+        self.teamCastles.forEach(teamCastle =>{
+            if(foundCastle.id == teamCastle.id){
+                if(turn == 2){
+                    teamCastle.x = foundCastle.castle_talk;
+                }
+                if(turn == 4){
+                    teamCastle.y = foundCastle.castle_talk;
+                }  
+                if(turn >= 5){
+                    self.log("castle_talk: " + foundCastle.castle_talk);
+                    if(foundCastle.castle_talk == 100){
+                        teamCastle.buildCounter.total++;
+                        teamCastle.signalBuilding = true;
+                        teamCastle.silentCount = 0;
+                    }
+                    else if(foundCastle.castle_talk == 101){
+                        teamCastle.signalBuilding = false;
+                        teamCastle.silentCount = 0;
+                    } else {
+                        //If no castle_talk visible, start checking. After certain amout of time, assume destroyed
+                        teamCastle.silentCount++;
+                        if(teamCastle.silentCount >= 10) {
+                            teamCastle.signalBuilding = false; 
+                        }
+                    }
+                    /*else if(foundCastle.castle_talk >= 1){
+                        self.log("Castle talk: " + foundCastle.castle_talk);
+                        self.log("Output: " + combat.UNITTYPE[foundCastle.castle_talk]);
+                        teamCastle.buildCounter[combat.UNITTYPE[foundCastle.castle_talk].toLowerCase()]++;
+                        teamCastle.buildCounter.total++;
+                        self.log(teamCastle.buildCounter);
+                    }*/
+                }
+            }
+        });
+    });
+    self.teamCastles.sort((a,b) => {
+        /*if(movement.getDistance(self.me, a) > movement.getDistance(self.me, b)) {
+            return -1;
+        } else {
+            return 1;
+        }*/
+        if(a.id == self.me.id) {
+            return -1;
+        } else if (b.id == self.me.id) {
+            return 1;
+        }
+    });
+};
+
+/** Castle should calculate the locations of the enemy castles using the recorded postions. Use mirror castle method. 
+ * Input : the location of the friendly castles
+ * Output: mirrored images of the enemy castles
+ */
+castle.mirrorCastle = (myLocation, fullMap) => {
+    const {x, y} = myLocation;
+    const Ax = fullMap.length - x - 1;
+    const Ay = fullMap.length - y - 1;
+    const isHorizontal = movement.isHorizontalReflection(fullMap);
+    
+    if(isHorizontal)
+    {
+        return {x: x, y: Ay}
+    }
+    else
+    {
+        return {x: Ax, y: y};
+    }
+};
+
+/** Method to make decision about attacking the enemy units
+ * 1. if attackable anemies around, start attacking on your own
+ * 2. if enemies in visible range, create prophets and attack
+ * 3. otherwise signal other friendly castles about status on the units build
+ */
+castle.makeDecision = (self, otherCastles, hasSignalToSend) => {
+
+    const visibleEnemies= combat.getVisibleEnemies(self);
+    const attackableEnemies = combat.filterByAttackable(self, visibleEnemies);
+
+    
+    //if there are any attackable enemies nearby, castle will start attacking instead of building any other units
+    if(attackableEnemies > 0){
+        const dx = attackableEnemies[0].x - self.me.x;
+        const dy = attackableEnemies[0].y - self.me.y;
+
+        self.log('Attackable enemies attacking');
+        return self.attack(dx, dy);
+    //if there are any enemies in a visible range, castle will start building PHROPHETS
+    } else if(visibleEnemies.length > 0){
+        self.log('Enemies in the visible range, building phrophets');
+        return castle.findUnitPlace(self, 'PROPHET');
+    }
+
+    //otherwise castles will signal which castle has done building the units and will take decisions accordingly
+    const checkSignal = otherCastles.findIndex(castle =>{
+        return castle.signalBuilding
+    });
+
+    self.log("Signal: " +  checkSignal);
+    //self.log(JSON.stringify(self.getVisibleRobots().filter(bots => {return bots.castle_talk > 0})));
+    //self.log(JSON.stringify(otherCastles));
+
+    if(checkSignal <= 0 && !otherCastles[0].mirrorCastleDestroyed) {
+        otherCastles[0].signalBuilding = true;
+        self.castleTalk(100);
+        //If there is a signal to send, forgo building unit for one turn and ensure signal sent
+        if (hasSignalToSend) {
+            self.log("Attempting to send signal.....");
+            return;
+        } else {
+            return castle.buildFromQueue(self)
+        }
+    }
+    else{
+
+        self.log('Not building units, differeing to other castles');
+        otherCastles[0].signalBuilding = false;
+        self.castleTalk(101);
+        return
+    }  
+
+};
+
+
+ /**
+  * Check castle talk message from units other than castles, if found, treat it as the x-coord or y-coord of a destroyed enemy castle
+  * remove the destroyed enemy castle from the array of enemy castles, and set self.target to null
+  */
+ castle.checkUnitCastleTalk = (self) => {
+    const alliedUnits = self.getVisibleRobots().filter(bot =>{
+        return bot.team === self.me.team && bot.castle_talk;
+    });
+    const length = alliedUnits.length;
+    let enemyCastlesLength = self.enemyCastles.length;
+    
+
+    for(let i = 0; i < length; ++i)
+    {  
+        self.log("Castle talk received: " + alliedUnits[i].castle_talk);
+        //self.log("Enemy castles: ");
+        //self.log(self.enemyCastles);
+        let messageValue = alliedUnits[i].castle_talk;
+        
+        //Castle talk is in the range 0-63 inclusive, reserved for coords - assume as destroyed enemy castle loc
+        if(messageValue >= 0 && messageValue < 64)
+        {
+            //Look for a partial message from the bot in receivedMessages
+            for(let j = 0; j < self.receivedMessages.length; ++j)
+            {
+                if(alliedUnits[i].id === self.receivedMessages[j].id)
+                {
+                    self.receivedMessages[j].y = messageValue;
+                    const enemyCastle = self.receivedMessages.splice(j, 1)[0];
+                    j -= 1;
+                    //Remove from enemy Castles array if match coords and store in pending message
+                    for(let k = 0; k < enemyCastlesLength; ++k)
+                    {
+                        if(movement.positionsAreEqual(enemyCastle, self.enemyCastles[k]))
+                        {
+                            const removedCastle = self.enemyCastles.splice(k,1)[0];
+                            enemyCastlesLength = self.enemyCastles.length;
+                            self.teamCastles.forEach(tc => {
+                                if(movement.positionsAreEqual(enemyCastle, movement.getMirrorCastle(tc, self.map))) {
+                                    tc.mirrorCastleDestroyed = true;
+                                }
+                            });
+                            //self.log("Enemy castle removed from array----------------------------------------------------------------------------------------")
+                            //self.log(self.target);
+                            //self.log(removedCastle);
+                            if(movement.positionsAreEqual(self.target, removedCastle) && enemyCastlesLength > 0)
+                            {
+                                self.target = self.enemyCastles[0];
+                                self.pendingMessages.push(communication.positionToSignal(self.target, self.map));
+                                self.log("Signal stored-------------------------------------------------------------------------------------------");
+                                //self.log(self.pendingMessages);
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+            //No partial message yet, add partial message to receivedMessages
+            self.receivedMessages.push({id: alliedUnits[i].id, x: messageValue});
+        }
+    }
+    return;
+ };
+
+ /**
+  * Checks whether there are pending messages to broadcast, pop it from the list and broadcast it if there is enough fuel
+  */
+castle.signalNewUnitTarget = (self) =>{
+    if(self.pendingMessages.length > 0)
+    {
+        if(self.fuel > self.map.length)
+        {
+            const newTarget = self.pendingMessages.pop();
+            self.signal(newTarget, self.map.length*self.map.length);
+            self.log("Signal sent to units, " + newTarget + "---------------------------------------------------------------------------------------------------------");
+            return true;
+        }
+        else
+        {
+            self.log("Not enough fuel to send signal");
+        }
+    }
+    return false;
+};
+
+/**
+ * Function that gets an array of locations representing positions close to a number of resource depots. Prioritizes bigger clusters
+ * and filters by locations that are between from a range limit (dictated by the `competitionIndex` param in the function) and roughly 
+ * the midpoint is `searchAggressively` is set to true or filters by locations roughly on the castle's side of the map if `searchAggressively`
+ * is false. NOTE: All sorting places higher priority locations lower in the list (i.e. `clusters[0]` will be highest priority)
+ * 
+ * @param self Castle calling method
+ * @param minClusterSize Filters out any clusters with less local depots than this value
+ * @param searchAggressively Boolean indicating whether to filter for depots that the enemy might be targeting. If true, filters for
+ * locations that are past the midpoint between calling castle and it's mirror castle but before the range limit. If false, filters for
+ * locations just past the midpoint or closer to the castle
+ * @param competitionIndex Value from 0 to 1 indicating how far between the calling castle and the enemy castle we should set our rangeLimit
+ * for how far we are willing to compete for resource. E.g. if competitionIndex=0.5, we will only search for resources that are at most halfway
+ * between castle and mirror castle. In all practicality this value should be greater than 0.5 as the "searchAggressive" case assumes this index
+ * is greater than the midpoint (i.e. 0.5)
+ * @return Returns an array of objects that include a location and other information about a tile close to other resource depots
+ */
+castle.findDepotClusters = (self, minClusterSize, competitionIndex, searchAggressively) => {
+    //Internal helper function that is self-explanatory. Needed because we are often searching for coordiantes in a range
+    const valueIsBetween = (value, a, b) => {
+        return value <= Math.max(a,b) && value >= Math.min(a,b);
+    };
+
+    let clusters = [];
+    
+    const mapHorizonal = movement.isHorizontalReflection(self.map);
+    const castleDistXY = movement.getDistanceXY(self.me, movement.getMirrorCastle(self.me, self.map));
+    const castleDistance = castleDistXY.x + castleDistXY.y;
+    //Following four objects are numerous locations to determine range between with to search
+    const midPoint = {x: self.map.length/2, y: self.map.length/2}; //Midpoint
+    const rangeLimit = { //Max coordinate in x or y direction - only use one!
+        x: (midPoint.x > self.me.x) ? self.me.x+(castleDistance*competitionIndex) : self.me.x-(castleDistance*competitionIndex), 
+        y: (midPoint.y > self.me.y) ? self.me.y+(castleDistance*competitionIndex) : self.me.y-(castleDistance*competitionIndex)
+    }; 
+    const conservativeMid = { //Something just before midPoint - allows us to account for things in middle better
+        x: (midPoint.x > self.me.x) ? midPoint.x-2 : midPoint.x+2,
+        y: (midPoint.y > self.me.y) ? midPoint.y-2 : midPoint.y+2
+    };
+    const generousMid = { //Something just after midPoint - allows us to account for things in middle better
+        x: (midPoint.x > self.me.x) ? midPoint.x+2 : midPoint.x-2,
+        y: (midPoint.y > self.me.y) ? midPoint.y+2 : midPoint.y-2
+    };
+    const castleBorder = { //End of map on castle's side of map - allows us to account for everything else on our side of midpoint
+        x: (midPoint.x > self.me.x) ? 0 : self.map.length-1,
+        y: (midPoint.y > self.me.y) ? 0 : self.map.length-1
+    };
+
+    for(let y = 0; y < self.map.length; y++) {
+        for(let x = 0; x < self.map.length; x++) {
+            if(self.karbonite_map[y][x] || self.fuel_map[y][x]) {
+                let currentCheck = {x: x, y: y, count: -1, dist: -1};
+                currentCheck = castle.processLocalDepots(self, currentCheck);
+                if(currentCheck.count < minClusterSize) {
+                    continue;
+                }
+                let nearbyIndex = clusters.findIndex(depot => {
+                    return movement.getDistance(currentCheck, depot) <= 9 && depot.count >= currentCheck.count;
+                });
+                //If nothing nearby, add to clusters
+                if(nearbyIndex < 0) {
+                    clusters.push(currentCheck);
+                //If nearby cluster but current better, add to cluster
+                } else if (clusters[nearbyIndex].count > currentCheck.count || clusters[nearbyIndex].dist > currentCheck.count) {
+                    clusters[nearbyIndex] = currentCheck;
+                }
+            }
+        }
+    }
+    self.log("IN CLUSTER SEARCH");
+    self.log(clusters.length);
+    //Filter for those within reasonable range for which we can compete and aren't closer to another friendly castle
+    clusters = clusters.filter(target => {
+        let closerTeamCastle = false;
+        self.teamCastles.forEach(castle => {
+            if(castle.id != self.me.id) {
+                //Filter out if another castle is closer to target
+                if(movement.getDistance(self.me, target) > movement.getDistance(castle, target)) {
+                    closerTeamCastle = true;
+                }
+            } else {
+                //Filter out if this castle is close enough to target to have created initial pilgrims for it
+                if(movement.getDistance(castle, target) <= 16) {
+                    closerTeamCastle = true;
+                }
+            }
+        });
+        return !closerTeamCastle;
+    });
+
+    //If search aggressively, filter for targets just before midpoint to compete with opponent
+    if(searchAggressively) {
+        clusters = clusters.filter(cluster => {
+            if(mapHorizonal) {
+                return valueIsBetween(cluster.y, rangeLimit.y, conservativeMid.y);
+            } else {
+                //Check if between rangeLimit and slightly before midpoint
+                return valueIsBetween(cluster.x, rangeLimit.x, conservativeMid.x);
+            }
+        });
+    //Otherwise, filter for things just pst midpoint or closer 
+    } else {
+        clusters = clusters.filter(cluster => {
+            if(mapHorizonal) {
+                return valueIsBetween(cluster.y, castleBorder.y, generousMid.y);
+            } else {
+                return valueIsBetween(cluster.x, castleBorder.x, generousMid.x);
+            }
+        });
+    }
+    //Handling edge cases where spots are close and can watched by a single prophet
+    let i = 0;
+    while(i < clusters.length) {
+        let nearby = clusters.findIndex(c => {
+            return !movement.positionsAreEqual(clusters[i], c) && movement.getDistance(clusters[i], c) <= 32;
+        });
+        //Find anything nearby, remove if nearby has smaller count or is farther from base. If nearby has higher count
+        //or is closer to base, filter out current cluster instead. Repeat until all nearby or this cluster removed
+        while(nearby >= 0) {
+            if(clusters[nearby].count > clusters[i].count) {
+                clusters.splice(i, 1);
+            } else if (clusters[nearby].count < clusters[i].count) {
+                clusters.splice(nearby, 1);
+            } else {
+                if(clusters[nearby].dist < clusters[i].dist) {
+                    clusters.splice(i, 1);
+                } else if(clusters[nearby].dist > clusters[i].dist) {
+                    clusters.splice(nearby, 1);
+                } else {
+                    if(movement.getDistance(self.me, clusters[i]) > movement.getDistance(self.me, clusters[nearby])) {
+                        clusters.splice(i, 1);
+                    } else {
+                        clusters.splice(nearby, 1);
+                    }
+                }
+            }
+            nearby = clusters.findIndex(c => {
+                return !movement.positionsAreEqual(clusters[i], c) && movement.getDistance(clusters[i], c) <= 32;
+            });
+        }
+        i++;
+    }
+
+    self.log("END CLUSTER SEARCH...RESULTS:");
+    self.log(clusters);
+    //Return sorted by count size
+    return clusters.sort((a,b) => { return b.count - a.count; });
+};
+
+/**
+ * Method to determine how many resource depots are around a given location.
+ * @param self MyRobot object to access map
+ * @param location Location to evaluate
+ * @return Object contain location coordinates, count of number of depots within +/- 3 tiles in
+ * x and y direction, plus sum of all R^2 distances to depots (smaller number means closer to all tiles)
+ */
+castle.processLocalDepots = (self, location) => {
+    let count = 0;
+    let dist = 0;
+    for(let y = location.y-3; y <= location.y+3; y++) {
+        for(let x = location.x-3; x <= location.x+3; x++) {
+            if(self._bc_check_on_map(x, y)) {
+                if(self.karbonite_map[y][x] || self.fuel_map[y][x]) {
+                    ++count;
+                    dist += movement.getDistance(location, {x: x, y: y});
+                }
+            }
+        }
+    }
+    return { x: location.x, y: location.y, count: count, dist: dist};
+};
+
 const pilgrim = {};
 pilgrim.maxKarbonite = SPECS.UNITS[SPECS.PILGRIM].KARBONITE_CAPACITY;
 pilgrim.maxFuel = SPECS.UNITS[SPECS.PILGRIM].FUEL_CAPACITY;
@@ -1371,10 +1934,10 @@ pilgrim.doAction = (self) => {
     
     if (self.role === 'UNASSIGNED') {
         self.base = movement.findAdjacentBase(self);
-        //Tweaking to set base not directly on top of castle, because causing pathfinding issues
-        //self.base = {x: self.me.x, y: self.me.y};
+        if(self.base === null) {
+            self.base = {x: self.me.x, y: self.me.y};
+        }
         self.log("Set base as " + JSON.stringify(self.base));
-        //Gets nearby base, checks turn
         self.role = 'PIONEER';
         communication.initTeamCastleInformation(self);
         //Set target base on castle signal
@@ -1462,9 +2025,28 @@ pilgrim.takePioneerAction = (self) => {
         return movement.moveAlongPath(self);
     //If at target, become miner
     } else {
-        self.role = 'MINER';
-        self.log('pilgrim PIONEER ' + self.id + ' becoming MINER');
-        return pilgrim.takeMinerAction(self);
+        const localBases = self.getVisibleRobots().filter(bot => {
+            return bot.team === self.me.team && bot.unit <= 1 && movement.getDistance(self.me, bot) <= 49;
+        });
+        localBases.sort((a,b) => {
+            return movement.getDistance(self.me, b) - movement.getDistance(self.me, a);
+        });
+        //If nothing around, assume it should be a church-builder
+        if(localBases.length === 0) {
+            //Build church if you can
+            if(self.fuel >= SPECS.UNITS[SPECS.CHURCH].CONSTRUCTION_FUEL && self.karbonite >= SPECS.UNITS[SPECS.CHURCH].CONSTRUCTION_KARBONITE) {
+                return pilgrim.buildChurch(self);
+            //Otherwise, tell base that you want to build, and at least try to mine so you can deposit once church build. 
+            } else {
+                self.castleTalk(121);
+                return self.mine();
+            }
+        } else {
+            self.base = {x: localBases[0].x, y: localBases[0].y};
+            self.role = 'MINER';
+            self.log('pilgrim PIONEER ' + self.id + ' becoming MINER');
+            return pilgrim.takeMinerAction(self);
+        }
     }
 };
 
@@ -1568,6 +2150,37 @@ pilgrim.updateResourceTarget = (self) => {
     }
     //Update path accordingly
     movement.aStarPathfinding(self, self.me, self.target, false);
+};
+
+/**
+ * Function to for a pilgrim to build a church. Assumes pilgrim is at best local depot, so 
+ */
+pilgrim.buildChurch = (self) => {
+    let bestCount = 0;
+    let bestDist = 0;
+    let bestLoc;
+    for(let i = -1; i<= 1; i++) {   
+        for(let j = -1; j<= 1; j++) {
+            const loc = {x: (self.me.x + i), y: (self.me.y+j)}; 
+            if(!movement.isPassable(loc, self.map, self.getVisibleRobotMap()) 
+                || self.karbonite_map[loc.y][loc.x] || self.fuel_map[loc.y][loc.x]) {
+                continue;
+            }
+            const locInfo = castle.processLocalDepots(self, loc);
+            if(locInfo.count > bestCount) {
+                bestCount = locInfo.count;
+                bestDist = locInfo.dist;
+                bestLoc = {x: loc.x, y: loc.y, dx: i, dy: j};
+            } else if (locInfo.count === bestCount && bestDist > locInfo.dist) {
+                bestCount = locInfo.count;
+                bestDist = locInfo.dist;
+                bestLoc = {x: loc.x, y: loc.y, dx: i, dy: j};
+            }
+        }
+    }
+    self.base = {x: bestLoc.x, y: bestLoc.y};
+    self.log('pilgrim ' + self.id + ' building a church at [' + bestLoc.x + ',' + bestLoc.y +']'); 
+    return self.buildUnit(1, bestLoc.dx, bestLoc.dy); 
 };
 
 const prophet = {};
@@ -1870,10 +2483,31 @@ prophet.takeDestroyerAction = (self) =>  {
 
     if(movement.positionsAreEqual(self.target, self.me))
     {
-        self.log('At target, Waiting...');
-        return;
+        //Check there is a pilgrim trying to get to this target depot
+        const nearbyPilgrims = self.getVisibleRobots().filter(bot => {
+            return bot.team === self.me.team && bot.unit === 2 && movement.getDistance(self.me, bot) <= 2;
+        });
+        console.log(nearbyPilgrims);
+        //If not, just wait
+        if(nearbyPilgrims.length === 0) {
+            self.log('At target, Waiting...');
+            return;
+        //If pilgrim wants spot, change target to somewhere else and move off depot for them
+        } else {
+            self.log("CHANGING TARGET SO PILGRIM CAN MINE/BUILD A CHURCH");
+            self.target = movement.findNearestLocation(self, self.me);
+        }
     }
 
+    //Check for edge case where pilgrim on target, in which case adjust target
+    if(self.path.length === 1) {
+        const botId = self.getVisibleRobotMap()[self.target.y][self.target.x];
+        if(botId > 0 && (self.getRobot(botId).unit === 2 && self.getRobot(botId).team === self.me.team)) {
+            self.log("CHANGING TARGET BECAUSE PILGRIM MINING/BUILDING A CHURCH ON TARGET");
+            self.target = movement.findNearestLocation(self, self.me);
+            self.path = [];
+        }
+    }
     //If no path yet
     if(self.path.length === 0)
     {
@@ -1890,552 +2524,6 @@ prophet.takeDestroyerAction = (self) =>  {
 
     self.log('DESTROYER prophet ' + self.id + ' moving towards target, Current: [' + self.me.x + ',' + self.me.y + ']');
     return movement.moveAlongPath(self);
-};
-
-const castle = {};
-
-
-castle.doAction = (self) => {
-
-    self.log("castle" + self.id + "taking turn.");
-  
-    castle.recordPosition(self);
-    castle.findPosition(self);
-    if(self.me.turn === 5)
-    {
-        self.enemyCastles = movement.getEnemyCastleLocations(self.teamCastles, self.map);
-        self.log("Enemy castles: ");
-        self.log(self.enemyCastles);
-        const competitionDepots = castle.findDepotClusters(self, 3, 0.7, true);
-        const prophetArray = [];
-        competitionDepots.forEach(depot => {
-            prophetArray.push({unit: "PROPHET", x: depot.x, y: depot.y});
-        });
-        self.castleBuildQueue = prophetArray.concat(self.castleBuildQueue);
-        self.log(self.castleBuildQueue);
-    }
-
-    //On first turn:
-    //  1. add to castleBuildQueue with pilgrims for each local karbonite depot
-    //  2. add to castleBuildQueue with pilgrims for each local fuel depot
-    //  3. add to castleBuildQueue a single crusader targeting the mirror castle.
-    //This ensures that all local depots are filled and a crusader will be built after
-    if(self.me.turn === 1)
-    {
-        
-        const karboniteDepots = movement.getResourcesInRange(self.me, 16, self.karbonite_map);
-        karboniteDepots.forEach(depot => {
-            self.castleBuildQueue.push({unit: "PILGRIM", x: depot.x, y: depot.y});
-        });
-
-        const fuelDepots = movement.getResourcesInRange(self.me, 16, self.fuel_map);
-        fuelDepots.forEach(depot => {
-            self.castleBuildQueue.push({unit: "PILGRIM", x: depot.x, y: depot.y});
-        });
-        
-        const mirrorCastle = movement.getMirrorCastle(self.me, self.map);
-        self.target = mirrorCastle;
-        self.log(self.castleBuildQueue);
-        return castle.buildFromQueue(self);
-    }
-    else if (self.me.turn <= 4) 
-    {
-        self.log("BUILD QUEUE NON-EMPTY");
-        self.log(self.castleBuildQueue);
-        const botsInQueue = self.castleBuildQueue.length;
-        //Keep queue at reasonable size, adding another crusader as necessary so crusaders are continually build
-        if (botsInQueue <= 5) {
-            self.castleBuildQueue.push({unit: "CRUSADER", x: self.target.x, y: self.target.y});
-        }
-        return castle.buildFromQueue(self);
-    }
-    else 
-    {
-        castle.checkUnitCastleTalk(self);
-        const hasSignalToSend = castle.signalNewUnitTarget(self);
-        const botsInQueue = self.castleBuildQueue.length;
-        //If there are still pilgrims of prophets to build, prioritize those unique units
-        if(botsInQueue > 0 && ((self.castleBuildQueue[0].unit == "PILGRIM") || (self.castleBuildQueue[0].unit == "PROPHET"))) {
-            return castle.buildFromQueue(self);
-        //Keep queue at reasonable size, adding another prophet as necessary so prophets are continually build
-        } else if (botsInQueue <= 5) {
-            self.castleBuildQueue.push({unit: "CRUSADER", x: self.target.x, y: self.target.y});
-        }
-        return castle.makeDecision(self, self.teamCastles, hasSignalToSend);
-    }
-};
-
-/** Method to check if any of the adjacent tile is available. Place the unit if true.
- */
-castle.findUnitPlace = (self, unitType) => {
-    for(let i = -1; i<= 1; i++){   
-        for(let j = -1; j<= 1; j++){
-            const location = {x: (self.me.x + i), y: (self.me.y +j)}; 
-            if(movement.isPassable(location, self.map, self.getVisibleRobotMap()))
-            {
-                //Send signal starting at turn 3 so you don't overrride location communication at start
-                /*if(self.me.turn > 4) {
-                    self.castleTalk(SPECS[unitType]);
-                }*/
-
-                self.log('castle ' + self.id + ' building unit ' + unitType + ' at [' + (self.me.x+i) + ',' + (self.me.y+j) +']'); 
-                return self.buildUnit(SPECS[unitType], i, j);       
-            }
-        }
-    }
-    return;
-};
-
-/**
- * Method to build next unit pushed on `castleBuildQueue`. Currently no checks that should be implemented
- */
-castle.buildFromQueue = (self) => {
-    const nextBuild = self.castleBuildQueue[0];
-    const botsOnMap = combat.getVisibleAllies(self).length;
-    let buildCount = 0;  
-    let fuelCap = 0; 
-    if(self.me.turn > 20) {
-        /*Take lesser of 1. bots built and 2. bots on map
-          1. Case for when castle destroyed and new one starts building - ensures it starts sooner rather than when 
-             bots at destroyed castle eventually eliminated
-          2. Case for when you've built a lot but bots keep getting destroyed - ensures that you don't stop building
-             if you need more on the map
-        */
-        buildCount = Math.min(self.teamCastles[0].buildCounter.total, botsOnMap);
-        fuelCap = 50+5*buildCount; //25+25*self.teamCastles.length;
-    }
-    //If past very start of game and fuel amount low, don't build a unit
-    if(self.fuel < fuelCap) {
-        self.log('not building unit to conserve fuel');
-        return;
-    //If you are able to build next unit, signal coordinates so it knows where to go and build it
-    } else if(self.fuel >= SPECS.UNITS[SPECS[nextBuild.unit]].CONSTRUCTION_FUEL && 
-       self.karbonite >= SPECS.UNITS[SPECS[nextBuild.unit]].CONSTRUCTION_KARBONITE) {
-        self.castleBuildQueue.shift();
-        self.signal(communication.positionToSignal(nextBuild, self.map), 2);
-        return castle.findUnitPlace(self, nextBuild.unit);
-    } else {
-        self.log('cannot build unit ' + nextBuild.unit + '- not enough resources');
-        return;
-    }
-};
-
-/** Each castle will try to locate and record the positions of the friendly castles at the start of the game
- * Input: self = this is the reference to the object to the calling method. 
- * Output: returnPosition = return value containing the positions of the friendly castle       
- *  */
-castle.recordPosition = (self) => {
-    let turn = self.me.turn;
-    if(turn <= 2){
-        self.castleTalk(self.me.x);
-    }
-    else if(turn <= 4){
-        self.castleTalk(self.me.y);
-    }
-};
-
-/**Find positions of the friendly castles. 
- * Input: self, this is the reference to the object to the calling method.
- * Output: positions of other friendly castles.
- */
-castle.findPosition = (self) => {
-    //Filter by those that have a castle talk, since apparently unit does not appear if not in vision radius
-    const bots = self.getVisibleRobots().filter(bot =>{
-        return bot.team === self.me.team && bot.castle_talk > 0;
-    });
-    let turn = self.me.turn;
-    const buildCounter = {
-        pilgrims:0,
-        crusader:0,
-        prophet:0,
-        total:0
-    };
-    const maxDist = -2*Math.pow(self.map.length, 2)-1;
-
-    bots.forEach(foundCastle => {
-        const addedToTeamCastles = self.teamCastles.findIndex(c => {
-            return c.id === foundCastle.id;
-        });
-        //Init an item in teamCastles if not already in teamCastles for initial turns
-        if (addedToTeamCastles < 0 && turn < 5) {
-            self.teamCastles.push({
-                id: foundCastle.id,
-                x: 0, 
-                y: 0, 
-                buildCounter: buildCounter, 
-                signalBuilding: false,
-                mirrorCastleDestroyed: false
-            });
-        }
-
-        self.teamCastles.forEach(teamCastle =>{
-            if(foundCastle.id == teamCastle.id){
-                if(turn == 2){
-                    teamCastle.x = foundCastle.castle_talk;
-                }
-                if(turn == 4){
-                    teamCastle.y = foundCastle.castle_talk;
-                }  
-                if(turn >= 5){
-                    self.log("castle_talk: " + foundCastle.castle_talk);
-                    if(foundCastle.castle_talk == 100){
-                        teamCastle.buildCounter.total++;
-                        teamCastle.signalBuilding = true;
-                    }
-                    else if(foundCastle.castle_talk == 101){
-                        teamCastle.signalBuilding = false;
-                    }
-                    /*else if(foundCastle.castle_talk >= 1){
-                        self.log("Castle talk: " + foundCastle.castle_talk);
-                        self.log("Output: " + combat.UNITTYPE[foundCastle.castle_talk]);
-                        teamCastle.buildCounter[combat.UNITTYPE[foundCastle.castle_talk].toLowerCase()]++;
-                        teamCastle.buildCounter.total++;
-                        self.log(teamCastle.buildCounter);
-                    }*/
-                }
-            }
-        });
-    });
-    self.teamCastles.sort((a,b) => {
-        /*if(movement.getDistance(self.me, a) > movement.getDistance(self.me, b)) {
-            return -1;
-        } else {
-            return 1;
-        }*/
-        if(a.id == self.me.id) {
-            return -1;
-        } else if (b.id == self.me.id) {
-            return 1;
-        }
-    });
-};
-
-/** Castle should calculate the locations of the enemy castles using the recorded postions. Use mirror castle method. 
- * Input : the location of the friendly castles
- * Output: mirrored images of the enemy castles
- */
-castle.mirrorCastle = (myLocation, fullMap) => {
-    const {x, y} = myLocation;
-    const Ax = fullMap.length - x - 1;
-    const Ay = fullMap.length - y - 1;
-    const isHorizontal = movement.isHorizontalReflection(fullMap);
-    
-    if(isHorizontal)
-    {
-        return {x: x, y: Ay}
-    }
-    else
-    {
-        return {x: Ax, y: y};
-    }
-};
-
-/** Method to make decision about attacking the enemy units
- * 1. if attackable anemies around, start attacking on your own
- * 2. if enemies in visible range, create prophets and attack
- * 3. otherwise signal other friendly castles about status on the units build
- */
-castle.makeDecision = (self, otherCastles, hasSignalToSend) => {
-
-    const visibleEnemies= combat.getVisibleEnemies(self);
-    const attackableEnemies = combat.filterByAttackable(self, visibleEnemies);
-
-    
-    //if there are any attackable enemies nearby, castle will start attacking instead of building any other units
-    if(attackableEnemies > 0){
-        const dx = attackableEnemies[0].x - self.me.x;
-        const dy = attackableEnemies[0].y - self.me.y;
-
-        self.log('Attackable enemies attacking');
-        return self.attack(dx, dy);
-    //if there are any enemies in a visible range, castle will start building PHROPHETS
-    } else if(visibleEnemies.length > 0){
-        self.log('Enemies in the visible range, building phrophets');
-        return castle.findUnitPlace(self, 'PROPHET');
-    }
-
-    //otherwise castles will signal which castle has done building the units and will take decisions accordingly
-    const checkSignal = otherCastles.findIndex(castle =>{
-        return castle.signalBuilding
-    });
-
-    self.log("Signal: " +  checkSignal);
-    //self.log(JSON.stringify(self.getVisibleRobots().filter(bots => {return bots.castle_talk > 0})));
-    //self.log(JSON.stringify(otherCastles));
-
-    if(checkSignal <= 0 && !otherCastles[0].mirrorCastleDestroyed) {
-        otherCastles[0].signalBuilding = true;
-        self.castleTalk(100);
-        //If there is a signal to send, forgo building unit for one turn and ensure signal sent
-        if (hasSignalToSend) {
-            self.log("Attempting to send signal.....");
-            return;
-        } else {
-            return castle.buildFromQueue(self)
-        }
-    }
-    else{
-
-        self.log('Not building units, differeing to other castles');
-        otherCastles[0].signalBuilding = false;
-        self.castleTalk(101);
-        return
-    }  
-
-};
-
-
- /**
-  * Check castle talk message from units other than castles, if found, treat it as the x-coord or y-coord of a destroyed enemy castle
-  * remove the destroyed enemy castle from the array of enemy castles, and set self.target to null
-  */
- castle.checkUnitCastleTalk = (self) => {
-    const alliedUnits = self.getVisibleRobots().filter(bot =>{
-        return bot.team === self.me.team && bot.castle_talk;
-    });
-    const length = alliedUnits.length;
-    let enemyCastlesLength = self.enemyCastles.length;
-    
-
-    for(let i = 0; i < length; ++i)
-    {  
-        self.log("Castle talk received: " + alliedUnits[i].castle_talk);
-        //self.log("Enemy castles: ");
-        //self.log(self.enemyCastles);
-        let messageValue = alliedUnits[i].castle_talk;
-        
-        //Castle talk is in the range 0-63 inclusive, reserved for coords - assume as destroyed enemy castle loc
-        if(messageValue >= 0 && messageValue < 64)
-        {
-            //Look for a partial message from the bot in receivedMessages
-            for(let j = 0; j < self.receivedMessages.length; ++j)
-            {
-                if(alliedUnits[i].id === self.receivedMessages[j].id)
-                {
-                    self.receivedMessages[j].y = messageValue;
-                    const enemyCastle = self.receivedMessages.splice(j, 1)[0];
-                    j -= 1;
-                    //Remove from enemy Castles array if match coords and store in pending message
-                    for(let k = 0; k < enemyCastlesLength; ++k)
-                    {
-                        if(movement.positionsAreEqual(enemyCastle, self.enemyCastles[k]))
-                        {
-                            const removedCastle = self.enemyCastles.splice(k,1)[0];
-                            enemyCastlesLength = self.enemyCastles.length;
-                            self.teamCastles.forEach(tc => {
-                                if(movement.positionsAreEqual(enemyCastle, movement.getMirrorCastle(tc, self.map))) {
-                                    tc.mirrorCastleDestroyed = true;
-                                }
-                            });
-                            //self.log("Enemy castle removed from array----------------------------------------------------------------------------------------")
-                            //self.log(self.target);
-                            //self.log(removedCastle);
-                            if(movement.positionsAreEqual(self.target, removedCastle) && enemyCastlesLength > 0)
-                            {
-                                self.target = self.enemyCastles[0];
-                                self.pendingMessages.push(communication.positionToSignal(self.target, self.map));
-                                self.log("Signal stored-------------------------------------------------------------------------------------------");
-                                //self.log(self.pendingMessages);
-                                return;
-                            }
-                        }
-                    }
-                }
-            }
-            //No partial message yet, add partial message to receivedMessages
-            self.receivedMessages.push({id: alliedUnits[i].id, x: messageValue});
-        }
-    }
-    return;
- };
-
- /**
-  * Checks whether there are pending messages to broadcast, pop it from the list and broadcast it if there is enough fuel
-  */
-castle.signalNewUnitTarget = (self) =>{
-    if(self.pendingMessages.length > 0)
-    {
-        if(self.fuel > self.map.length)
-        {
-            const newTarget = self.pendingMessages.pop();
-            self.signal(newTarget, self.map.length*self.map.length);
-            self.log("Signal sent to units, " + newTarget + "---------------------------------------------------------------------------------------------------------");
-            return true;
-        }
-        else
-        {
-            self.log("Not enough fuel to send signal");
-        }
-    }
-    return false;
-};
-
-/**
- * Function that gets an array of locations representing positions close to a number of resource depots. Prioritizes bigger clusters
- * and filters by locations that are between from a range limit (dictated by the `competitionIndex` param in the function) and roughly 
- * the midpoint is `searchAggressively` is set to true or filters by locations roughly on the castle's side of the map if `searchAggressively`
- * is false. NOTE: All sorting places higher priority locations lower in the list (i.e. `clusters[0]` will be highest priority)
- * 
- * @param self Castle calling method
- * @param minClusterSize Filters out any clusters with less local depots than this value
- * @param searchAggressively Boolean indicating whether to filter for depots that the enemy might be targeting. If true, filters for
- * locations that are past the midpoint between calling castle and it's mirror castle but before the range limit. If false, filters for
- * locations just past the midpoint or closer to the castle
- * @param competitionIndex Value from 0 to 1 indicating how far between the calling castle and the enemy castle we should set our rangeLimit
- * for how far we are willing to compete for resource. E.g. if competitionIndex=0.5, we will only search for resources that are at most halfway
- * between castle and mirror castle. In all practicality this value should be greater than 0.5 as the "searchAggressive" case assumes this index
- * is greater than the midpoint (i.e. 0.5)
- * @return Returns an array of objects that include a location and other information about a tile close to other resource depots
- */
-castle.findDepotClusters = (self, minClusterSize, competitionIndex, searchAggressively) => {
-    //Internal helper function that is self-explanatory. Needed because we are often searching for coordiantes in a range
-    const valueIsBetween = (value, a, b) => {
-        return value <= Math.max(a,b) && value >= Math.min(a,b);
-    };
-
-    let clusters = [];
-    
-    const mapHorizonal = movement.isHorizontalReflection(self.map);
-    const castleDistXY = movement.getDistanceXY(self.me, movement.getMirrorCastle(self.me, self.map));
-    const castleDistance = castleDistXY.x + castleDistXY.y;
-    //Following four objects are numerous locations to determine range between with to search
-    const midPoint = {x: self.map.length/2, y: self.map.length/2}; //Midpoint
-    const rangeLimit = { //Max coordinate in x or y direction - only use one!
-        x: (midPoint.x > self.me.x) ? self.me.x+(castleDistance*competitionIndex) : self.me.x-(castleDistance*competitionIndex), 
-        y: (midPoint.y > self.me.y) ? self.me.y+(castleDistance*competitionIndex) : self.me.y-(castleDistance*competitionIndex)
-    }; 
-    const conservativeMid = { //Something just before midPoint - allows us to account for things in middle better
-        x: (midPoint.x > self.me.x) ? midPoint.x-2 : midPoint.x+2,
-        y: (midPoint.y > self.me.y) ? midPoint.y-2 : midPoint.y+2
-    };
-    const generousMid = { //Something just after midPoint - allows us to account for things in middle better
-        x: (midPoint.x > self.me.x) ? midPoint.x+2 : midPoint.x-2,
-        y: (midPoint.y > self.me.y) ? midPoint.y+2 : midPoint.y-2
-    };
-    const castleBorder = { //End of map on castle's side of map - allows us to account for everything else on our side of midpoint
-        x: (midPoint.x > self.me.x) ? 0 : self.map.length-1,
-        y: (midPoint.y > self.me.y) ? 0 : self.map.length-1
-    };
-
-    for(let y = 0; y < self.map.length; y++) {
-        for(let x = 0; x < self.map.length; x++) {
-            if(self.karbonite_map[y][x] || self.fuel_map[y][x]) {
-                let currentCheck = {x: x, y: y, count: -1, dist: -1};
-                currentCheck = castle.processLocalDepots(self, currentCheck);
-                if(currentCheck.count < minClusterSize) {
-                    continue;
-                }
-                let nearbyIndex = clusters.findIndex(depot => {
-                    return movement.getDistance(currentCheck, depot) <= 9 && depot.count >= currentCheck.count;
-                });
-                //If nothing nearby, add to clusters
-                if(nearbyIndex < 0) {
-                    clusters.push(currentCheck);
-                //If nearby cluster but current better, add to cluster
-                } else if (clusters[nearbyIndex].count > currentCheck.count || clusters[nearbyIndex].dist > currentCheck.count) {
-                    clusters[nearbyIndex] = currentCheck;
-                }
-            }
-        }
-    }
-    self.log("IN CLUSTER SEARCH");
-    self.log(clusters.length);
-    //Filter for those within reasonable range for which we can compete and aren't closer to another friendly castle
-    clusters = clusters.filter(target => {
-        let closerTeamCastle = false;
-        self.teamCastles.forEach(castle => {
-            if(castle.id != self.me.id) {
-                //Filter out if another castle is closer to target
-                if(movement.getDistance(self.me, target) > movement.getDistance(castle, target)) {
-                    closerTeamCastle = true;
-                }
-            } else {
-                //Filter out if this castle is close enough to target to have created initial pilgrims for it
-                if(movement.getDistance(castle, target) <= 16) {
-                    closerTeamCastle = true;
-                }
-            }
-        });
-        return !closerTeamCastle;
-    });
-    self.log(clusters.length);
-
-    //If search aggressively, filter for targets just before midpoint to compete with opponent
-    if(searchAggressively) {
-        self.log("RangeLimit: " + JSON.stringify(rangeLimit));
-        self.log("Mid: " + JSON.stringify(midPoint));
-        clusters = clusters.filter(cluster => {
-            self.log("Cluster: " + JSON.stringify(cluster));
-            if(mapHorizonal) {
-                return valueIsBetween(cluster.y, rangeLimit.y, conservativeMid.y);
-            } else {
-                //Check if between rangeLimit and slightly before midpoint
-                return valueIsBetween(cluster.x, rangeLimit.x, conservativeMid.x);
-            }
-        });
-    //Otherwise, filter for things just pst midpoint or closer 
-    } else {
-        clusters = clusters.filter(cluster => {
-            if(mapHorizonal) {
-                return valueIsBetween(cluster.y, castleBorder.y, generousMid.y);
-            } else {
-                return valueIsBetween(cluster.x, castleBorder.x, generousMid.x);
-            }
-        });
-    }
-    //Handling edge cases where spots are close and can watched by a single prophet
-    clusters = clusters.filter(cluster => {
-        let nearby = clusters.findIndex(c => {
-            return !movement.positionsAreEqual(cluster, c) && movement.getDistance(cluster, c) <= 32;
-        });
-        //Find anything nearby, remove if nearby has smaller count or is farther from base. If nearby has higher count
-        //or is closer to base, filter out current cluster instead. Repeat until all nearby or this cluster removed
-        while(nearby >= 0) {
-            if(clusters[nearby].count > cluster.count) {
-                return false;
-            } else if (clusters[nearby].count < cluster.count) {
-                clusters.splice(nearby, 1);
-            } else {
-                if(movement.getDistance(self.me, cluster) > movement.getDistance(self.me, clusters[nearby])) {
-                    return false;
-                } else {
-                    clusters.splice(nearby, 1);
-                }
-            }
-            nearby = clusters.findIndex(c => {
-                return !movement.positionsAreEqual(cluster, c) && movement.getDistance(cluster, c) <= 32;
-            });
-        }
-        return true;      
-    });
-
-    self.log(clusters);
-    self.log("END CLUSTER SEARCH");
-    //Return sorted by count size
-    return clusters.sort((a,b) => { return b.count - a.count; });
-};
-
-/**
- * Method to determine how many resource depots are around a given location.
- * @param self MyRobot object to access map
- * @param location Location to evaluate
- * @return Object contain location coordinates, count of number of depots within +/- 3 tiles in
- * x and y direction, plus sum of all R^2 distances to depots (smaller number means closer to all tiles)
- */
-castle.processLocalDepots = (self, location) => {
-    let count = 0;
-    let dist = 0;
-    for(let y = location.y-3; y <= location.y+3; y++) {
-        for(let x = location.x-3; x <= location.x+3; x++) {
-            if(self._bc_check_on_map(x, y)) {
-                if(self.karbonite_map[y][x] || self.fuel_map[y][x]) {
-                    ++count;
-                    dist += movement.getDistance(location, {x: x, y: y});
-                }
-            }
-        }
-    }
-    return { x: location.x, y: location.y, count: count, dist: dist};
 };
 
 const church = {};

--- a/test/castle.unittest.js
+++ b/test/castle.unittest.js
@@ -201,4 +201,158 @@ describe('Castle Helpers Unit Tests', function(){
         });
     });
 
+    describe('assessLocalPilgrims() tests', function() {
+        it('should only count local pilgrims when adding to queue', function(done) {
+            myBot = new MyRobot();
+            myBot.macro.localPilgrims = 0;
+            const karbAlterations = [
+                {x: 3, y: 0, value:true},
+                {x: 0, y: 3, value:true},
+                {x: 2, y: 2, value:true}
+            ]
+            const fuelAlterations = [
+                {x: 1, y: 0, value:true},
+                {x: 0, y: 1, value:true},
+                {x: 4, y: 4, value:true}
+            ]
+
+            mockGame.alterMap("karbonite_map", karbAlterations);
+            mockGame.alterMap("fuel_map", fuelAlterations);
+            mockGame.createNewRobot(myBot, 0, 0, 0, 0);
+
+            //Things that shouldn't be counted
+            mockGame.createNewRobot(new MyRobot(), 1, 0, 0, 3);
+            mockGame.createNewRobot(new MyRobot(), 4, 4, 0, 2);
+            mockGame.createNewRobot(new MyRobot(), 3, 0, 1, 2);
+
+            output = castle.assessLocalPilgrims(myBot);
+
+            expect(myBot.castleBuildQueue).eql([]);
+
+            done();
+        });
+
+        it('should do nothing if local pilgrims greater or equal to macro value', function(done) {
+            myBot = new MyRobot();
+            myBot.macro.localPilgrims = 2;
+            const karbAlterations = [
+                {x: 3, y: 0, value:true},
+                {x: 0, y: 3, value:true},
+                {x: 2, y: 2, value:true}
+            ]
+            const fuelAlterations = [
+                {x: 1, y: 0, value:true},
+                {x: 0, y: 1, value:true},
+                {x: 4, y: 4, value:true}
+            ]
+
+            mockGame.alterMap("karbonite_map", karbAlterations);
+            mockGame.alterMap("fuel_map", fuelAlterations);
+            mockGame.createNewRobot(myBot, 0, 0, 0, 0);
+
+            mockGame.createNewRobot(new MyRobot(), 1, 2, 0, 2);
+            mockGame.createNewRobot(new MyRobot(), 2, 2, 0, 2);
+
+            output = castle.assessLocalPilgrims(myBot);
+
+            expect(myBot.castleBuildQueue).eql([]);
+
+            done();
+        });
+
+        it('should do nothing if more unoccupied depots than local pilgrims', function(done) {
+            myBot = new MyRobot();
+            myBot.macro.localPilgrims = 5;
+            const karbAlterations = [
+                {x: 3, y: 0, value:true},
+                {x: 0, y: 3, value:true},
+                {x: 2, y: 2, value:true}
+            ]
+            const fuelAlterations = [
+                {x: 1, y: 0, value:true},
+                {x: 0, y: 1, value:true},
+                {x: 4, y: 4, value:true}
+            ]
+
+            mockGame.alterMap("karbonite_map", karbAlterations);
+            mockGame.alterMap("fuel_map", fuelAlterations);
+            mockGame.createNewRobot(myBot, 0, 0, 0, 0);
+
+            //5 local depots, 3 local pilgrims on depot, 1 not on depot
+            mockGame.createNewRobot(new MyRobot(), 1, 0, 0, 2);
+            mockGame.createNewRobot(new MyRobot(), 2, 2, 0, 2);
+            mockGame.createNewRobot(new MyRobot(), 3, 0, 0, 2);
+            mockGame.createNewRobot(new MyRobot(), 3, 2, 0, 2);
+
+            output = castle.assessLocalPilgrims(myBot);
+
+            expect(myBot.castleBuildQueue).eql([]);
+
+            done();
+        });
+
+        it('should not add pilgrims for depots already in castleBuildQueue', function(done) {
+            myBot = new MyRobot();
+            myBot.macro.localPilgrims = 5;
+            const karbAlterations = [
+                {x: 3, y: 0, value:true},
+                {x: 0, y: 3, value:true},
+                {x: 2, y: 2, value:true}
+            ]
+            const fuelAlterations = [
+                {x: 1, y: 0, value:true},
+                {x: 0, y: 1, value:true},
+                {x: 4, y: 4, value:true}
+            ]
+
+            mockGame.alterMap("karbonite_map", karbAlterations);
+            mockGame.alterMap("fuel_map", fuelAlterations);
+            mockGame.createNewRobot(myBot, 0, 0, 0, 0);
+
+            //5 local depots, 4 local pilgrims on depot, last depot in queue
+            mockGame.createNewRobot(new MyRobot(), 1, 0, 0, 2);
+            mockGame.createNewRobot(new MyRobot(), 2, 2, 0, 2);
+            mockGame.createNewRobot(new MyRobot(), 3, 0, 0, 2);
+            mockGame.createNewRobot(new MyRobot(), 0, 1, 0, 2);
+            myBot.castleBuildQueue = [{unit: "PILGRIM", x: 0, y: 3}];
+
+            output = castle.assessLocalPilgrims(myBot);
+
+            expect(myBot.castleBuildQueue).to.deep.include.members([{unit: "PILGRIM", x: 0, y: 3}]);
+
+            done();
+        });
+
+        it('should add pilgrims for unoccupied depots not in castleBuildQueue', function(done) {
+            myBot = new MyRobot();
+            myBot.macro.localPilgrims = 5;
+            const karbAlterations = [
+                {x: 3, y: 0, value:true},
+                {x: 0, y: 3, value:true},
+                {x: 2, y: 2, value:true}
+            ]
+            const fuelAlterations = [
+                {x: 1, y: 0, value:true},
+                {x: 0, y: 1, value:true},
+                {x: 4, y: 4, value:true}
+            ]
+
+            mockGame.alterMap("karbonite_map", karbAlterations);
+            mockGame.alterMap("fuel_map", fuelAlterations);
+            mockGame.createNewRobot(myBot, 0, 0, 0, 0);
+
+            //5 local depots, 4 local pilgrims on depot, last depot not in queue
+            mockGame.createNewRobot(new MyRobot(), 1, 0, 0, 2);
+            mockGame.createNewRobot(new MyRobot(), 2, 2, 0, 2);
+            mockGame.createNewRobot(new MyRobot(), 3, 0, 0, 2);
+            mockGame.createNewRobot(new MyRobot(), 0, 1, 0, 2);
+
+            output = castle.assessLocalPilgrims(myBot);
+
+            expect(myBot.castleBuildQueue).to.deep.include.members([{unit: "PILGRIM", x: 0, y: 3}]);
+
+            done();
+        });
+    });
+
 });

--- a/test/communication.unittests.js
+++ b/test/communication.unittests.js
@@ -142,7 +142,7 @@ describe('Communication Helpers Unit Tests', function() {
             expect(myBot.pendingMessages).to.eql([]);
             expect(communication.checkAndReportEnemyCastleDestruction(myBot)).to.equals(true);
             expect(myBot.pendingMessages).to.have.lengthOf(2);
-            expect(myBot.pendingMessages).to.eql([3, 2]);
+            expect(myBot.pendingMessages).to.eql([4, 3]);
 
             done();
         });
@@ -155,7 +155,7 @@ describe('Communication Helpers Unit Tests', function() {
             expect(myBot.pendingMessages).to.eql([]);
             expect(communication.checkAndReportEnemyCastleDestruction(myBot)).to.equals(true);
             expect(myBot.pendingMessages).to.have.lengthOf(2);
-            expect(myBot.pendingMessages).to.eql([3, 2]);
+            expect(myBot.pendingMessages).to.eql([4, 3]);
             done();
         });
 

--- a/test/crusader.unittests.js
+++ b/test/crusader.unittests.js
@@ -85,10 +85,11 @@ describe('Crusader Unit Tests', function() {
     });
 
     describe('takeAttackerAction() tests', function() {
-        it('ATTACKERS with no base should identify enemy castles', function(done) {
+        it('ATTACKERS with no base should set target to enemy castle', function(done) {
             let stubCheckEnemyCastle = mockGame.replaceMethod("communication", "checkAndReportEnemyCastleDestruction").returns(false);
             myBot.base = null;
             myBot.target = {x: 9, y: 3};
+            myBot.squadSize = 0; //To ensure move by attacker - on test map it's skipped
 
             //Unknown, get mirror castle returns null?
             output = crusader.takeAttackerAction(myBot);
@@ -113,6 +114,7 @@ describe('Crusader Unit Tests', function() {
             myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
             myBot.path = [{x: 3, y: 3}];
             myBot.target = {x: 9, y: 3};
+            myBot.squadSize = 0; //To ensure move by attacker - on test map attackerMoves cannot be 0 unfortunately
 
             //Teammate in attackable range
             mockGame.createNewRobot(new MyRobot(), 1, 7, 0, 2);
@@ -153,26 +155,26 @@ describe('Crusader Unit Tests', function() {
             done();
         });
 
-        it("ATTACKERS with a path should move for 6 turns iff they have fuel to move", function(done) {
+        it("ATTACKERS with a path should move for some amount of turns iff they have fuel to move", function(done) {
             let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns("moved successfully");
             myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
             myBot.path = [{x: 3, y: 3}];
             myBot.target = {x: 9, y: 3};
 
             //Enough fuel, still turns to move
-            myBot.attackerMoves = 5;
+            myBot.attackerMoves = -1; //Adjust because on small map won't make many moves
             myBot.fuel = 4;
             output = crusader.takeAttackerAction(myBot);
 
-            expect(myBot.attackerMoves).equals(6);
+            expect(myBot.attackerMoves).equals(0);
             expect(output).equals("moved successfully");
 
             //Not enough fuel, still turns to move
-            myBot.attackerMoves = 5;
+            myBot.attackerMoves = -1;
             myBot.fuel = 3;
             output = crusader.takeAttackerAction(myBot);
 
-            expect(myBot.attackerMoves).equals(5);
+            expect(myBot.attackerMoves).equals(-1); //Adjust because on small map won't make many moves
             expect(output).to.be.undefined;
             
 

--- a/test/myRobot.unittests.js
+++ b/test/myRobot.unittests.js
@@ -1,48 +1,45 @@
 const mocha = require('mocha');
 const chai = require('chai');
 const MyRobot = require('../projectUtils/psuteam7botCompiled.js').MyRobot;
-
-/*Choose an assertion style. I am used to 'expect', but there is also 'should' and 'assert'
-Basically different ways of making assertions. See https://www.chaijs.com/guide/styles/ for more documentation
-Full Chai expect documentation for reference is here: https://www.chaijs.com/api/bdd/
-*/
+const mockBC19 = require('../projectUtils/mockGame.js');
 const expect = chai.expect;
 
 
-//'describe' serves as a way to represent of kind of test. Everything in this describe block are 'MyRobot Unit Tests'
 describe('MyRobot Unit Tests', function() {
-    //Everything in this block is an 'Exanple' test. Some categories might be 'Mining', 'Movement', 'Strategy', etc.
-    describe('Properties tests', function() {
-        //'it' is the actual test that is run, with expectations being evaluated
-        it('should be an MyRobot object', function(done) {
-            const bot = new MyRobot();
-            const type = typeof bot;
+    let myBot;
+    let mockGame;
+    let output;
+    beforeEach(function() {
+        myBot = new MyRobot();
+        mockGame = new mockBC19('../projectUtils/psuteam7botCompiled.js');
+        mockGame.initEmptyMaps(10);
+    });
 
-            //Create various assertions 
-            expect(type).equals('object');
-            expect(bot).to.be.an.instanceof(MyRobot);
-            //Done is called at completion of test to know this specific test can terminate
-            done();
-        });
+    afterEach(function() {
+        mockGame.undoSinonMethods();
+    });
 
-        //Use multiple 'it' blocks to test different aspects for the broader 'describe' category
-        it('should have certain properties and lack others', function(done) {
-            const bot = new MyRobot();
+    it('should doAction of bot type', function(done) {
+        let stubMessages = [
+            "castle action taken",
+            "church action taken",
+            "pilgrim action taken",
+            "crusader action taken",
+            "prophet action taken"
+        ]
+        mockGame.replaceMethod("castle", "doAction").returns(stubMessages[0]);
+        mockGame.replaceMethod("church", "doAction").returns(stubMessages[1]);
+        mockGame.replaceMethod("pilgrim", "doAction").returns(stubMessages[2]);
+        mockGame.replaceMethod("crusader", "doAction").returns(stubMessages[3]);
+        mockGame.replaceMethod("prophet", "doAction").returns(stubMessages[4]);
 
-            expect(bot).to.have.property('id');
-            expect(bot).to.have.property('fuel');
-            expect(bot).to.have.property('karbonite');
-            expect(bot).to.not.have.property('ID');
-            expect(bot).to.not.have.property('nonExistantProperty');
+        for(let i = 0; i < 5; i++) {
+            myBot = new MyRobot();
+            mockGame.createNewRobot(myBot, i, i, 0, i);
+            output = myBot.turn();
+            expect(output).to.equal(stubMessages[i]);
+        }
 
-            done();
-        });
-
-        //You can also skip tests or entire 'describe' blocks - useful for tests that are unfinished.
-        //Similarly, there is a '.only' syntax to exclusively test an 'it' or 'describe' block
-        it.skip('test to ignore', function(done) {
-            //This test is not done
-            expect(true).equals(false);
-        })
+        done();
     });
 });

--- a/test/pilgrim.unittests.js
+++ b/test/pilgrim.unittests.js
@@ -9,11 +9,479 @@ const expect = chai.expect;
 
 describe('Pilgrim Unit Tests', function() {
     let mockGame;
-    describe.skip('Role objectives tests', function(done) {
-        beforeEach(function() {
-            mockGame = new mockBC19();
-            mockGame.initEmptyMaps(10);
+    let myBot;
+    let localCastle;
+    let output;
+    beforeEach(function() {
+        myBot = new MyRobot();
+        localCastle = new MyRobot();
+        mockGame = new mockBC19('../projectUtils/psuteam7botCompiled.js');
+        mockGame.initEmptyMaps(10);
+        mockGame.createNewRobot(localCastle, 0, 0, 0, 0);
+        mockGame.createNewRobot(myBot, 1, 1, 0, 2);
+    })
+
+    afterEach(function() {
+        mockGame.undoSinonMethods();
+    })
+
+    describe('doAction() tests', function() {
+        it('should do nothing if in undefined role', function(done) {
+            myBot.role = "TESTROLE";
+
+            output = pilgrim.doAction(myBot);
+
+            expect(output).to.be.undefined;
+            done();
+        });
+
+        it('UNASSIGNED pilgrims', function(done) {
+            myBot.role = "TESTROLE";
+
+            output = pilgrim.doAction(myBot);
+
+            expect(output).to.be.undefined;
+            done();
         })
+
+        it('PIONEER/MINER pilgrims should just call respective action methods', function(done) {
+            let stubTakePioneerAction = mockGame.replaceMethod("pilgrim", "takePioneerAction").returns('taking pioneer action');
+            let stubTakeMinerAction = mockGame.replaceMethod("pilgrim", "takeMinerAction").returns('taking miner action');
+            myBot.role = "PIONEER";
+
+            output = pilgrim.doAction(myBot);
+
+            expect(myBot.base).to.be.null;
+            expect(output).equals('taking pioneer action');
+
+            myBot.role = "MINER";
+
+            output = pilgrim.doAction(myBot);
+
+            expect(myBot.base).to.be.null;
+            expect(output).equals('taking miner action');
+            done();
+        })
+    })
+
+    describe('takePioneerAction() tests', function() {
+        it('should set target to karbonite depot if no target and odd number of local pilgrims', function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns('move made');
+            const karbAlterations = [
+                {x: 3, y: 4, value:true},
+                {x: 1, y: 5, value:true}
+            ];
+            const fuelAlterations = [
+                {x: 4, y: 3, value:true},
+                {x: 5, y: 1, value:true}
+            ];
+            mockGame.alterMap("karbonite_map", karbAlterations);
+            mockGame.alterMap("fuel_map", fuelAlterations);
+
+            //One local pilgrim (itself)
+            output = pilgrim.takePioneerAction(myBot);
+
+            expect(myBot.target).to.not.be.null;
+            expect(myBot.target).eql({x: 3, y: 4});
+            expect(myBot.karbonite_map[myBot.target.y][myBot.target.x]).to.be.true;
+            expect(myBot.fuel_map[myBot.target.y][myBot.target.x]).to.be.false;
+            expect(output).equals('move made');
+
+            //Still one local pilgrim
+            myBot.target = null;
+            mockGame.createNewRobot(new MyRobot(), 5, 5, 1, 2);
+            mockGame.createNewRobot(new MyRobot(), 9, 8, 0, 2);
+            output = pilgrim.takePioneerAction(myBot);
+
+            expect(myBot.target).to.not.be.null;
+            expect(myBot.target).eql({x: 3, y: 4});
+            expect(myBot.karbonite_map[myBot.target.y][myBot.target.x]).to.be.true;
+            expect(myBot.fuel_map[myBot.target.y][myBot.target.x]).to.be.false;
+            expect(output).equals('move made');
+
+            //Three local pilgrims
+            myBot.target = null;
+            mockGame.createNewRobot(new MyRobot(), 9, 7, 0, 2);
+            mockGame.createNewRobot(new MyRobot(), 8, 8, 0, 2);
+            output = pilgrim.takePioneerAction(myBot);
+
+            expect(myBot.target).to.not.be.null;
+            expect(myBot.target).eql({x: 3, y: 4});
+            expect(myBot.karbonite_map[myBot.target.y][myBot.target.x]).to.be.true;
+            expect(myBot.fuel_map[myBot.target.y][myBot.target.x]).to.be.false;
+            expect(output).equals('move made');
+            
+            done();
+        });
+
+        it('should set target to fuel depot if no target and even number of local pilgrims', function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns('move made');
+            const karbAlterations = [
+                {x: 3, y: 4, value:true},
+                {x: 1, y: 5, value:true}
+            ];
+            const fuelAlterations = [
+                {x: 4, y: 3, value:true},
+                {x: 5, y: 1, value:true}
+            ];
+            mockGame.alterMap("karbonite_map", karbAlterations);
+            mockGame.alterMap("fuel_map", fuelAlterations);
+            mockGame.createNewRobot(new MyRobot(), 2, 2, 0, 2);
+
+            //Two locals pilgrims
+            output = pilgrim.takePioneerAction(myBot);
+
+            expect(myBot.target).to.not.be.null;
+            expect(myBot.target).eql({x: 4, y: 3});
+            expect(myBot.karbonite_map[myBot.target.y][myBot.target.x]).to.be.false;
+            expect(myBot.fuel_map[myBot.target.y][myBot.target.x]).to.be.true;
+            expect(output).equals('move made');
+
+            //Still two local pilgrims
+            myBot.target = null;
+            mockGame.createNewRobot(new MyRobot(), 5, 5, 1, 2);
+            mockGame.createNewRobot(new MyRobot(), 9, 8, 0, 2);
+            output = pilgrim.takePioneerAction(myBot);
+
+            expect(myBot.target).to.not.be.null;
+            expect(myBot.target).eql({x: 4, y: 3});
+            expect(myBot.karbonite_map[myBot.target.y][myBot.target.x]).to.be.false;
+            expect(myBot.fuel_map[myBot.target.y][myBot.target.x]).to.be.true;
+            expect(output).equals('move made');
+
+            //Four local pilgrims
+            myBot.target = null;
+            mockGame.createNewRobot(new MyRobot(), 9, 7, 0, 2);
+            mockGame.createNewRobot(new MyRobot(), 8, 8, 0, 2);
+            output = pilgrim.takePioneerAction(myBot);
+
+            expect(myBot.target).to.not.be.null;
+            expect(myBot.target).eql({x: 4, y: 3});
+            expect(myBot.karbonite_map[myBot.target.y][myBot.target.x]).to.be.false;
+            expect(myBot.fuel_map[myBot.target.y][myBot.target.x]).to.be.true;
+            expect(output).equals('move made');
+
+            done();
+        });
+
+        it('should become miner if at target', function(done) {
+            let stubTakeMinerAction = mockGame.replaceMethod("pilgrim", "takeMinerAction").returns('becoming pilgrim');
+            myBot.target = {x: myBot.me.x, y: myBot.me.y};
+
+            //Two locals pilgrims
+            output = pilgrim.takePioneerAction(myBot);
+
+            expect(myBot.role).equals('MINER');
+            expect(output).equals('becoming pilgrim');
+
+            done();
+        });
+
+        it('should move towards target if not there yet', function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns('move made');
+            myBot.target = {x: myBot.me.x+1, y: myBot.me.y+1};
+
+            //Two locals pilgrims
+            output = pilgrim.takePioneerAction(myBot);
+
+            expect(output).equals('move made');
+
+            done();
+        });
+    });
+
+    describe('takeMinerAction() tests', function() {
+        it('should set target to depot of relatively less plentiful resource if no target', function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns('move made');
+            const karbAlterations = [
+                {x: 3, y: 4, value:true},
+                {x: 1, y: 5, value:true}
+            ];
+            const fuelAlterations = [
+                {x: 4, y: 3, value:true},
+                {x: 5, y: 1, value:true}
+            ];
+            mockGame.alterMap("karbonite_map", karbAlterations);
+            mockGame.alterMap("fuel_map", fuelAlterations);
+
+            //Relatively more karbonite, target fuel
+            myBot.karbonite = 10;
+            myBot.fuel = myBot.karbonite*5-1;
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(myBot.target).to.not.be.null;
+            expect(myBot.target).eql({x: 4, y: 3});
+            expect(myBot.karbonite_map[myBot.target.y][myBot.target.x]).to.be.false;
+            expect(myBot.fuel_map[myBot.target.y][myBot.target.x]).to.be.true;
+            expect(output).equals('move made');
+
+            //Relatively more fuel, target karbonite
+            myBot.karbonite = 10;
+            myBot.fuel = myBot.karbonite*5+1;
+            myBot.target = null;
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(myBot.target).to.not.be.null;
+            expect(myBot.target).eql({x: 3, y: 4});
+            expect(myBot.karbonite_map[myBot.target.y][myBot.target.x]).to.be.true;
+            expect(myBot.fuel_map[myBot.target.y][myBot.target.x]).to.be.false;
+            expect(output).equals('move made');
+
+            //Relatively equal resources, target karbonite
+            myBot.karbonite = 10;
+            myBot.fuel = myBot.karbonite*5;
+            myBot.target = null;
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(myBot.target).to.not.be.null;
+            expect(myBot.target).eql({x: 3, y: 4});
+            expect(myBot.karbonite_map[myBot.target.y][myBot.target.x]).to.be.true;
+            expect(myBot.fuel_map[myBot.target.y][myBot.target.x]).to.be.false;
+            expect(output).equals('move made');
+
+            //Edge case with 0 karbonite, target karbonite
+            myBot.karbonite = 0;
+            myBot.fuel = 3;
+            myBot.target = null;
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(myBot.target).to.not.be.null;
+            expect(myBot.target).eql({x: 3, y: 4});
+            expect(myBot.karbonite_map[myBot.target.y][myBot.target.x]).to.be.true;
+            expect(myBot.fuel_map[myBot.target.y][myBot.target.x]).to.be.false;
+            expect(output).equals('move made');
+            
+            done();
+        });
+
+        
+        it('should give resources if near adjacent base and fuel or karbonite at carrying capacity', function(done) {
+            myBot.target = {x: myBot.me.x, y: myBot.me.y};
+            myBot.me.karbonite = 20;
+
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(output['action']).equals('give');
+            expect(output['dx']).equals(-1);
+            expect(output['dy']).equals(-1);
+
+            myBot.me.karbonite = 0;
+            myBot.me.fuel = 100;
+
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(output['action']).equals('give');
+            expect(output['dx']).equals(-1);
+            expect(output['dy']).equals(-1);
+
+            done();
+        });
+
+        it('should move towards base if not near castle, there is a path, and fuel or karbonite at carrying capacity', function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns('move made');
+            const returningPilgrim = new MyRobot();
+            mockGame.createNewRobot(returningPilgrim, 5, 5, 0, 2);
+            returningPilgrim.path = [{x: 2, y: 2}];
+            returningPilgrim.target = {x: myBot.me.x+1, y: myBot.me.y+1};
+            returningPilgrim.me.karbonite = 20;
+
+            output = pilgrim.takeMinerAction(returningPilgrim);
+
+            expect(output).equals('move made');
+
+            done();
+        });
+
+        it('should update path to base if no path and fuel or karbonite at carrying capacity', function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns('move made');
+            const returningPilgrim = new MyRobot();
+            mockGame.createNewRobot(returningPilgrim, 5, 5, 0, 2);
+            returningPilgrim.target = {x: localCastle.me.x, y: localCastle.me.y};
+            returningPilgrim.base = {x: localCastle.me.x, y: localCastle.me.y};
+            returningPilgrim.me.karbonite = 20;
+
+            output = pilgrim.takeMinerAction(returningPilgrim);
+
+            expect(returningPilgrim.path[0]).eql({x: localCastle.me.x, y: localCastle.me.y});
+            expect(output).equals('move made');
+
+            done();
+        });
+
+        it('should mine if not at carrying capacity and at target depot', function(done) {
+            myBot.target = {x: myBot.me.x, y: myBot.me.y};
+            myBot.me.karbonite = 19;
+            myBot.me.fuel = 99;
+
+            mockGame.alterMap("karbonite_map", [{x: myBot.me.x, y: myBot.me.y, value:true}])
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(output['action']).equals('mine');
+
+            done();
+        });
+
+        it('should move towards target if not at carrying capacity and not at target depot', function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns('move made');
+            myBot.target = {x: myBot.me.x+1, y: myBot.me.y+1};
+            myBot.me.karbonite = 19;
+            myBot.me.karbonite = 99;
+
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(output).equals('move made');
+
+            done();
+        });
+    });
+
+    describe('takeMinerAction() tests', function() {
+        it('should set target to depot of relatively less plentiful resource if no target', function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns('move made');
+            const karbAlterations = [
+                {x: 3, y: 4, value:true},
+                {x: 1, y: 5, value:true}
+            ];
+            const fuelAlterations = [
+                {x: 4, y: 3, value:true},
+                {x: 5, y: 1, value:true}
+            ];
+            mockGame.alterMap("karbonite_map", karbAlterations);
+            mockGame.alterMap("fuel_map", fuelAlterations);
+
+            //Relatively more karbonite, target fuel
+            myBot.karbonite = 10;
+            myBot.fuel = myBot.karbonite*5-1;
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(myBot.target).to.not.be.null;
+            expect(myBot.target).eql({x: 4, y: 3});
+            expect(myBot.karbonite_map[myBot.target.y][myBot.target.x]).to.be.false;
+            expect(myBot.fuel_map[myBot.target.y][myBot.target.x]).to.be.true;
+            expect(output).equals('move made');
+
+            //Relatively more fuel, target karbonite
+            myBot.karbonite = 10;
+            myBot.fuel = myBot.karbonite*5+1;
+            myBot.target = null;
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(myBot.target).to.not.be.null;
+            expect(myBot.target).eql({x: 3, y: 4});
+            expect(myBot.karbonite_map[myBot.target.y][myBot.target.x]).to.be.true;
+            expect(myBot.fuel_map[myBot.target.y][myBot.target.x]).to.be.false;
+            expect(output).equals('move made');
+
+            //Relatively equal resources, target karbonite
+            myBot.karbonite = 10;
+            myBot.fuel = myBot.karbonite*5;
+            myBot.target = null;
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(myBot.target).to.not.be.null;
+            expect(myBot.target).eql({x: 3, y: 4});
+            expect(myBot.karbonite_map[myBot.target.y][myBot.target.x]).to.be.true;
+            expect(myBot.fuel_map[myBot.target.y][myBot.target.x]).to.be.false;
+            expect(output).equals('move made');
+
+            //Edge case with 0 karbonite, target karbonite
+            myBot.karbonite = 0;
+            myBot.fuel = 3;
+            myBot.target = null;
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(myBot.target).to.not.be.null;
+            expect(myBot.target).eql({x: 3, y: 4});
+            expect(myBot.karbonite_map[myBot.target.y][myBot.target.x]).to.be.true;
+            expect(myBot.fuel_map[myBot.target.y][myBot.target.x]).to.be.false;
+            expect(output).equals('move made');
+            
+            done();
+        });
+
+        
+        it('should give resources if near adjacent base and fuel or karbonite at carrying capacity', function(done) {
+            myBot.target = {x: myBot.me.x, y: myBot.me.y};
+            myBot.me.karbonite = 20;
+
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(output['action']).equals('give');
+            expect(output['dx']).equals(-1);
+            expect(output['dy']).equals(-1);
+
+            myBot.me.karbonite = 0;
+            myBot.me.fuel = 100;
+
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(output['action']).equals('give');
+            expect(output['dx']).equals(-1);
+            expect(output['dy']).equals(-1);
+
+            done();
+        });
+
+        it('should move towards base if not near castle, there is a path, and fuel or karbonite at carrying capacity', function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns('move made');
+            const returningPilgrim = new MyRobot();
+            mockGame.createNewRobot(returningPilgrim, 5, 5, 0, 2);
+            returningPilgrim.path = [{x: 2, y: 2}];
+            returningPilgrim.target = {x: myBot.me.x+1, y: myBot.me.y+1};
+            returningPilgrim.me.karbonite = 20;
+
+            output = pilgrim.takeMinerAction(returningPilgrim);
+
+            expect(output).equals('move made');
+
+            done();
+        });
+
+        it('should update path to base if no path and fuel or karbonite at carrying capacity', function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns('move made');
+            const returningPilgrim = new MyRobot();
+            mockGame.createNewRobot(returningPilgrim, 5, 5, 0, 2);
+            returningPilgrim.target = {x: localCastle.me.x, y: localCastle.me.y};
+            returningPilgrim.base = {x: localCastle.me.x, y: localCastle.me.y};
+            returningPilgrim.me.karbonite = 20;
+
+            output = pilgrim.takeMinerAction(returningPilgrim);
+
+            expect(returningPilgrim.path[0]).eql({x: localCastle.me.x, y: localCastle.me.y});
+            expect(output).equals('move made');
+
+            done();
+        });
+
+        it('should mine if not at carrying capacity and at target depot', function(done) {
+            myBot.target = {x: myBot.me.x, y: myBot.me.y};
+            myBot.me.karbonite = 19;
+            myBot.me.fuel = 99;
+
+            mockGame.alterMap("karbonite_map", [{x: myBot.me.x, y: myBot.me.y, value:true}])
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(output['action']).equals('mine');
+
+            done();
+        });
+
+        it('should move towards target if not at carrying capacity and not at target depot', function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns('move made');
+            myBot.target = {x: myBot.me.x+1, y: myBot.me.y+1};
+            myBot.me.karbonite = 19;
+            myBot.me.karbonite = 99;
+
+            output = pilgrim.takeMinerAction(myBot);
+
+            expect(output).equals('move made');
+
+            done();
+        });
+    });
+
+
+    describe.skip('Role objectives tests', function(done) {
 
         it('MINERS without a target should identify and move towards a resource', function(done) {
             let returnValue;
@@ -158,11 +626,6 @@ describe('Pilgrim Unit Tests', function() {
     });
 
     describe('Mining tests', function() {
-        beforeEach(function() {
-            mockGame = new mockBC19();
-            mockGame.initEmptyMaps(10);
-        });
-
         it('should be able to mine if on a resource depot', function(done) {
             let returnValue;
             const myBot = new MyRobot();
@@ -293,55 +756,27 @@ describe('Pilgrim Unit Tests', function() {
     });
 
     describe('Method tests', function() {
-        describe('findClosestResource()', function(done) {
-            beforeEach(function() {
-                mockGame = new mockBC19();
-                mockGame.initEmptyMaps(10);
-            });
-
+        describe('findClosestResource() tests', function(done) {
             it('should return closest non-occupied resource', function(done) {
                 let returnValue;
                 const myBot = new MyRobot();
                 myBot.target = {x: 1, y: 1};
+                myBot.occupiedResources = [{x: 1, y: 1}, {x: 2, y: 2}];
                 const friendlyBot1 = new MyRobot();
                 const friendlyBot2 = new MyRobot();
-                myBot.me = {
-                    id: 10,
-                    team: 0,
-                    unit: 2, //Pilgrim
-                    x: 0,
-                    y: 0
-                }
-                friendlyBot1.me = {
-                    id: 1,
-                    team: 0,
-                    unit: 2, //Pilgrim
-                    x: 1,
-                    y: 1
-                }
-                friendlyBot2.me = {
-                    id: 2,
-                    team: 0,
-                    unit: 2, //Pilgrim
-                    x: 2,
-                    y: 2
-                }
-                myBot._bc_game_state = friendlyBot1._bc_game_state = friendlyBot2._bc_game_state = {
-                    visible: [myBot.me, friendlyBot1.me, friendlyBot2.me],
-                    shadow: null
-                };
-                myBot.occupiedResources = [{x: 1, y: 1}, {x: 2, y: 2}];
-                myBot._bc_game_state.shadow = friendlyBot1._bc_game_state.shadow = friendlyBot2._bc_game_state.shadow = 
-                [[10,0,0,0,0],
-                 [0,1,0,0,0],
-                 [0,0,2,0,0],
-                 [0,0,0,0,0],
-                 [0,0,0,0,0]];
-                myBot.karbonite_map = [[false,false,false,false,false],
-                                       [false,true,false,false,false],
-                                       [false,false,true,false,false],
-                                       [false,false,false,true,false],
-                                       [false,false,true,false,true]];
+                const karbAlterations = [
+                    {x: 1, y: 1, value:true},
+                    {x: 2, y: 2, value:true},
+                    {x: 3, y: 3, value:true},
+                    {x: 4, y: 4, value:true},
+                    {x: 2, y: 4, value:true}
+                ]
+
+                mockGame.removeAllBots();
+                mockGame.createNewRobot(myBot, 0, 0, 0, 2);
+                mockGame.createNewRobot(friendlyBot1, 1, 1, 0, 2);
+                mockGame.createNewRobot(friendlyBot2, 2, 2, 0, 2);
+                mockGame.alterMap("karbonite_map", karbAlterations);
     
                 returnValue = pilgrim.findClosestResource(myBot.me, myBot.karbonite_map, myBot.occupiedResources);
                 expect(returnValue).to.eql({x: 3, y: 3});
@@ -350,34 +785,60 @@ describe('Pilgrim Unit Tests', function() {
             });
         });
 
-        describe('isDepotOccupied()', function(done) {
-            beforeEach(function() {
-                mockGame = new mockBC19();
-                mockGame.initEmptyMaps(10);
-            });
-
+        describe('isDepotOccupied() tests', function(done) {
             it('should change nothing if target unoccupied', function(done) {
                 let returnValue;
                 const myBot = new MyRobot();
-                myBot._bc_game_state = {shadow: null};
-                myBot.me = {
-                    id: 1,
-                    unit: 2, //Pilgrim
-                    x: 0,
-                    y: 0
-                }
-                const startTarget = {x: 1, y: 1};
-                myBot._bc_game_state.shadow = 
-                [[1,0,0,0,0],
-                 [0,0,0,0,0],
-                 [0,0,0,0,0],
-                 [0,0,0,0,0],
-                 [0,0,0,0,0]];
-                myBot.karbonite_map = [[0,0,0,0,0],
-                                       [0,1,0,0,0],
-                                       [0,0,1,0,0],
-                                       [0,0,0,1,0],
-                                       [1,0,1,0,1]];
+                const startTarget = {x: 1, y: 1}
+                const karbAlterations = [
+                    {x: 1, y: 1, value:true},
+                    {x: 2, y: 2, value:true},
+                    {x: 3, y: 3, value:true},
+                    {x: 4, y: 4, value:true},
+                    {x: 0, y: 4, value:true},
+                    {x: 2, y: 4, value:true}
+                ];
+
+                mockGame.removeAllBots();
+                mockGame.createNewRobot(myBot, 0, 0, 0, 2);
+                mockGame.alterMap("karbonite_map", karbAlterations);
+    
+                returnValue = pilgrim.isDepotOccupied(myBot, startTarget);
+                expect(returnValue).to.be.false;
+                expect(myBot.occupiedResources).to.eql([]);
+    
+                done();
+            });
+
+            it('should change nothing if target occupied by bot that isnt friendly pilgrim', function(done) {
+                let returnValue;
+                const myBot = new MyRobot();
+                const friendlyBot = new MyRobot();
+                const startTarget = {x: 1, y: 1}
+                const karbAlterations = [
+                    {x: 1, y: 1, value:true},
+                    {x: 2, y: 2, value:true},
+                    {x: 3, y: 3, value:true},
+                    {x: 4, y: 4, value:true},
+                    {x: 0, y: 4, value:true},
+                    {x: 2, y: 4, value:true}
+                ];
+
+                //Same team, non-pilgrim unit on target
+                mockGame.removeAllBots();
+                mockGame.createNewRobot(myBot, 0, 0, 0, 2);
+                mockGame.createNewRobot(friendlyBot, 1, 1, 0, 3);
+                mockGame.alterMap("karbonite_map", karbAlterations);
+    
+                returnValue = pilgrim.isDepotOccupied(myBot, startTarget);
+                expect(returnValue).to.be.false;
+                expect(myBot.occupiedResources).to.eql([]);
+
+                //Pilgrim of different team on target
+                mockGame.removeAllBots();
+                mockGame.createNewRobot(myBot, 0, 0, 0, 2);
+                mockGame.createNewRobot(friendlyBot, 1, 1, 1, 2);
+                mockGame.alterMap("karbonite_map", karbAlterations);
     
                 returnValue = pilgrim.isDepotOccupied(myBot, startTarget);
                 expect(returnValue).to.be.false;
@@ -390,36 +851,20 @@ describe('Pilgrim Unit Tests', function() {
                 let returnValue;
                 const myBot = new MyRobot();
                 const friendlyBot = new MyRobot();
-                myBot.me = {
-                    id: 1,
-                    team: 0,
-                    unit: 2, //Pilgrim
-                    x: 0,
-                    y: 0
-                }
-                friendlyBot.me = {
-                    id: 2,
-                    team: 0,
-                    unit: 2, //Pilgrim
-                    x: 1,
-                    y: 1
-                }
-                myBot._bc_game_state = friendlyBot._bc_game_state = {
-                    visible: [myBot.me, friendlyBot.me],
-                    shadow: null
-                };
-                const startTarget = {x: 1, y: 1};
-                myBot._bc_game_state.shadow = friendlyBot._bc_game_state.shadow = 
-                [[1,0,0,0,0],
-                 [0,2,0,0,0],
-                 [0,0,0,0,0],
-                 [0,0,0,0,0],
-                 [0,0,0,0,0]];
-                myBot.karbonite_map = [[0,0,0,0,0],
-                                       [0,1,0,0,0],
-                                       [0,0,1,0,0],
-                                       [0,0,0,1,0],
-                                       [1,0,1,0,1]];
+                const startTarget = {x: 1, y: 1}
+                const karbAlterations = [
+                    {x: 1, y: 1, value:true},
+                    {x: 2, y: 2, value:true},
+                    {x: 3, y: 3, value:true},
+                    {x: 4, y: 4, value:true},
+                    {x: 0, y: 4, value:true},
+                    {x: 2, y: 4, value:true}
+                ];
+
+                mockGame.removeAllBots();
+                mockGame.createNewRobot(myBot, 0, 0, 0, 2);
+                mockGame.createNewRobot(friendlyBot, 1, 1, 0, 2);
+                mockGame.alterMap("karbonite_map", karbAlterations);
     
                 returnValue = pilgrim.isDepotOccupied(myBot, startTarget);
                 expect(returnValue).to.be.true;
@@ -429,25 +874,20 @@ describe('Pilgrim Unit Tests', function() {
             });
         });
 
-        describe('updateResourceTarget()', function(done) {
-            beforeEach(function() {
-                mockGame = new mockBC19();
-                mockGame.initEmptyMaps(10);
-            });
-
+        describe('updateResourceTarget() tests', function(done) {
             it('should change nothing if target unoccupied', function(done) {
                 let returnValue;
                 const myBot = new MyRobot();
                 const startTarget = myBot.target = {x: 1, y: 1};
                 const karbAlterations = [
-                    {x: 1, y: 1, value: true},
-                    {x: 2, y: 2, value: true},
-                    {x: 3, y: 3, value: true},
-                    {x: 4, y: 4, value: true}
+                    {x: 1, y: 1, value:true},
+                    {x: 2, y: 2, value:true},
+                    {x: 3, y: 3, value:true},
+                    {x: 4, y: 4, value:true}
                 ];
-
-                mockGame.alterMap("karbonite_map", karbAlterations);
+                mockGame.removeAllBots();
                 mockGame.createNewRobot(myBot, 0, 0, 0, 2);
+                mockGame.alterMap("karbonite_map", karbAlterations);
     
                 returnValue = pilgrim.updateResourceTarget(myBot);
                 expect(myBot.occupiedResources).to.eql([]);
@@ -470,7 +910,22 @@ describe('Pilgrim Unit Tests', function() {
                     {x: 4, y: 4, value: true}
                 ];
 
+                //Should work for karbonite
+                mockGame.removeAllBots();
                 mockGame.alterMap("karbonite_map", karbAlterations);
+                mockGame.createNewRobot(myBot, 0, 0, 0, 2);
+                mockGame.createNewRobot(friendlyBot1, 1, 1, 0, 2);
+                mockGame.createNewRobot(friendlyBot2, 2, 2, 0, 2);
+                
+    
+                returnValue = pilgrim.updateResourceTarget(myBot);
+                expect(myBot.occupiedResources).to.deep.include.members([{x: 1, y: 1}, {x: 2, y: 2}]);
+                expect(myBot.target).to.eql({x: 3, y: 3});
+
+                //Should work for fuel
+                mockGame.initEmptyMaps(10);
+                mockGame.removeAllBots();
+                mockGame.alterMap("fuel_map", karbAlterations);
                 mockGame.createNewRobot(myBot, 0, 0, 0, 2);
                 mockGame.createNewRobot(friendlyBot1, 1, 1, 0, 2);
                 mockGame.createNewRobot(friendlyBot2, 2, 2, 0, 2);

--- a/test/prophet.unittests.js
+++ b/test/prophet.unittests.js
@@ -54,36 +54,39 @@ describe('Prophet Unit Tests', function() {
         });
 
         it("UNASSIGNED bots should use the radio signal from the base if one exists", function(done) {
-            let stubDefenderAction = mockGame.replaceMethod("prophet", "takeDefenderAction").returns('skipping defender action');
+            let stubDestroyerAction = mockGame.replaceMethod("prophet", "takeDestroyerAction").returns('skipping destroyer action');
             let signalPos = communication.signalToPosition(17, mockGame.game.map);
             localCastle.me.signal = 17;
             localCastle.me.signal_radius = 2;
             mockGame._setCommunication(localCastle);
 
+            mockGame.alterMap("karbonite_map", [{x: signalPos.x, y: signalPos.y, value:true}]) //Force into destoryer path so defender section doesn't reset target
             output = prophet.doAction(myBot);
 
             expect(myBot.base).to.eql({x: 0, y: 3});
-            expect(myBot.role).equals("DEFENDER");
+            expect(myBot.role).equals("DESTROYER");
             expect(myBot.target).to.eql(signalPos);
-            expect(output).equals('skipping defender action');
+            expect(output).equals('skipping destroyer action');
 
             done();
         });
 
         it("UNASSIGNED bots should use getMirrorCastle if radio signal from the base DNE", function(done) {
-            let stubDefenderAction = mockGame.replaceMethod("prophet", "takeDefenderAction").returns('skipping defender action');
+            let stubDestroyerAction = mockGame.replaceMethod("prophet", "takeDestroyerAction").returns('skipping destroyer action');
+
+            mockGame.alterMap("karbonite_map", [{x: 18, y: 3, value:true}]) //Force into destoryer path so defender section doesn't reset target
 
             output = prophet.doAction(myBot);
 
             expect(myBot.base).to.eql({x: 0, y: 3});
-            expect(myBot.role).equals("DEFENDER");
+            expect(myBot.role).equals("DESTROYER");
             expect(myBot.target).to.eql({x: 18, y: 3});
-            expect(output).equals('skipping defender action');
+            expect(output).equals('skipping destroyer action');
 
             done();
         });
 
-        it("UNASSIGNED bots should become DEFENDERS if 2 or less local prophets, ATTACKERS otherwise", function(done) {
+        it("UNASSIGNED bots should become DEFENDERS if 8 or less local prophets, ATTACKERS otherwise", function(done) {
             let stubDefenderAction = mockGame.replaceMethod("prophet", "takeDefenderAction").returns('skipping defender action');
             let stubAttackerAction = mockGame.replaceMethod("prophet", "takeAttackerAction").returns('skipping attacker action');
             myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
@@ -94,26 +97,33 @@ describe('Prophet Unit Tests', function() {
             expect(myBot.role).equals("DEFENDER");
             expect(output).equals('skipping defender action');
 
-            //Two defenders in range of base, one out of range
+            //Eight defenders in range of base, one out of range
             myBot.role = "UNASSIGNED";
             mockGame.createNewRobot(new MyRobot(), 8, 3, 0, 4);
-            mockGame.createNewRobot(new MyRobot(), 8, 4, 0, 4);
+            mockGame.createNewRobot(new MyRobot(), 7, 3, 0, 4);
+            mockGame.createNewRobot(new MyRobot(), 8, 2, 0, 4);
+            mockGame.createNewRobot(new MyRobot(), 5, 3, 0, 4);
+            mockGame.createNewRobot(new MyRobot(), 0, 8, 0, 4);
+            mockGame.createNewRobot(new MyRobot(), 6, 6, 0, 4);
+            mockGame.createNewRobot(new MyRobot(), 0, 6, 0, 4);
+            mockGame.createNewRobot(new MyRobot(), 4, 5, 0, 4);
+
 
             output = prophet.doAction(myBot);
             
             expect(myBot.role).equals("DEFENDER");
             expect(output).equals('skipping defender action');
 
-            //Two defenders in range of base, one non-prophet also in range
+            //Eight defenders in range of base, one non-prophet also in range
             myBot.role = "UNASSIGNED";
-            mockGame.createNewRobot(new MyRobot(), 3, 3, 0, 3);
+            mockGame.createNewRobot(new MyRobot(), 3, 4, 0, 3);
 
             output = prophet.doAction(myBot);
 
             expect(myBot.role).equals("DEFENDER");
             expect(output).equals('skipping defender action');
 
-            //Three defenders in range of base
+            //Nine defenders in range of base
             myBot.role = "UNASSIGNED";
             mockGame.createNewRobot(new MyRobot(), 4, 4, 0, 4);
 

--- a/test/prophet.unittests.js
+++ b/test/prophet.unittests.js
@@ -369,6 +369,108 @@ describe('Prophet Unit Tests', function() {
 
     });
 
+    describe.only('takeDestroyerAction() tests', function() {
+        it('DESTROYERS with enemies in attackable range should just attack enemies', function(done) {
+            myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
+            myBot.path = [{x: 3, y: 3}];
+            myBot.target = {x: 19, y: 3};
+
+            //Teammate in attackable range
+            mockGame.createNewRobot(new MyRobot(), 1, 7, 0, 2);
+            output = prophet.takeDestroyerAction(myBot);
+
+            expect(output['action']).equals('move');
+
+            //Enemy out of attackable range
+            mockGame.createNewRobot(new MyRobot(), 9, 4, 1, 2);
+            output = prophet.takeDestroyerAction(myBot);
+
+            expect(output['action']).equals('move');
+
+            //Enemy in attackable range
+            mockGame.createNewRobot(new MyRobot(), 9, 3, 1, 2); 
+            output = prophet.takeDestroyerAction(myBot);
+
+            expect(output['action']).equals('attack');
+            expect(output['dx']).equals(8);
+            expect(output['dy']).equals(0);            
+
+            done();
+        });
+
+        it("DESTROYERS at target with no adjacent team pilgrims should wait", function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns("moved successfully");
+            myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
+            myBot.target = {x: myBot.me.x, y: myBot.me.y};
+
+            mockGame.createNewRobot(new MyRobot(), 3, 3, 0, 2);
+
+            output = prophet.takeDestroyerAction(myBot);
+
+            expect(output).to.be.undefined;
+
+            done();
+        });
+
+        it("DESTROYERS at target with adjacent team pilgrims should move to allow pilgrim access to depot", function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns("moved successfully");
+            myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
+            myBot.target = {x: 1, y: 3};
+
+            //Team pilgrim, adjust path
+            mockGame.createNewRobot(new MyRobot(), 2, 2, 0, 2);
+            output = prophet.takeDestroyerAction(myBot);
+
+            expect(myBot.target).to.not.eql({x: 1, y: 3});
+            expect(output).equals("moved successfully");
+
+            done();
+        });
+
+        it("DESTROYERS not at target with an empty path should create a path to target", function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns("moved successfully");
+            myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
+            myBot.target = {x: 19, y: 3};
+
+            output = prophet.takeDestroyerAction(myBot);
+
+            expect(myBot.path[0]).to.eql(myBot.target);
+            expect(output).equals("moved successfully");
+
+            done();
+        });
+
+        it("DESTROYERS not at target with an empty path should create a path to target", function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns("moved successfully");
+            myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
+            myBot.target = {x: 19, y: 3};
+
+            output = prophet.takeDestroyerAction(myBot);
+
+            expect(myBot.path[0]).to.eql(myBot.target);
+            expect(output).equals("moved successfully");
+
+            done();
+        });
+
+        it("DESTROYERS not at target with a path equal to 1 should check for team pilgrim on target and adjust target if so", function(done) {
+            let stubMoveAlongPath = mockGame.replaceMethod("movement", "moveAlongPath").returns("moved successfully");
+            myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
+            myBot.path = [{x: 3, y: 3}]; //Not a real path but w/e
+            myBot.target = {x: 3, y: 3};
+
+            //Team pilgrim, adjust path
+            mockGame.createNewRobot(new MyRobot(), 3, 3, 0, 2);
+            output = prophet.takeDestroyerAction(myBot);
+
+            expect(myBot.target).to.not.eql({x: 3, y: 3});
+            expect(myBot.path).to.deep.include(myBot.target);
+            expect(output).equals("moved successfully");
+
+            done();
+        });
+    });
+
     describe('fleeBehavior() tests', function() {
         it('should return false if no enemies in blindspot', function(done) {
             mockGame.createNewRobot(new MyRobot(), 5, 3, 1, 3);

--- a/test/prophet.unittests.js
+++ b/test/prophet.unittests.js
@@ -369,7 +369,7 @@ describe('Prophet Unit Tests', function() {
 
     });
 
-    describe.only('takeDestroyerAction() tests', function() {
+    describe('takeDestroyerAction() tests', function() {
         it('DESTROYERS with enemies in attackable range should just attack enemies', function(done) {
             myBot.base = {x: localCastle.me.x, y: localCastle.me.y};
             myBot.path = [{x: 3, y: 3}];


### PR DESCRIPTION
The monstrosity of a PR. Overall goal was creating methods for pilgrims to find depot clusters and build churchs plus introduce some macro stuff. However, lots of little adjustments were made and I will try to address them all as well as I can. Changes by file:

**`castle.js`**
- Added `makeMacroDecisions` to set `macro` object properties for castles. Implemented at turn 5 in `doAction`
- Added a karbonite cap when deciding whether to build. Not sure how much I like it - we may remove in final version.
- Added processes in `makeDecision` to add prophets and pilgrims to front of `castleBuildQueue` if more local defenders or pilgrims are needed.
- Tweaked decision making process to add defenders or pilgrims at front of queue even if not the building castle to ensure that other castles maintain these important bots for their area.
- Adjusted `messageValue` in `checkUnitCastleTalk` to account for change in `communication.js` based on edge case. See `communication.js` section for more.
- Tweaked `findDepotClusters` to be better (basically stale version of array was viewed each time, so nearby items were sometimes removing each other).

**`communication.js`**
- Adjusted output to handle edge case where `x` or `y` is 0 (and thus was being ignored)

**`crusader.js`**
- Updated `movesFromBase` to be relative to distance to mirror castle. Ensures that crusaders don't try to rally at point where they can be shot by enemy castle

**`pilgrim.js`**
- Adjusted `takePioneerAction` to account for case where base is not nearby and attempt to build church if this is the case
- Added `buildChurch` method to build a church

**`prophet.js`**
- Changed defender behavior to fan out close to base. Will no longer build attackers unless a lot of defenders built up
- Added edge cases for DESTROYER pilgrims where it should defer to a pilgrim targeting the same resource, moving off the target or resetting its target to somewhere closeby instead

**`robot.js`**
- Added `macro` object for castles

**Everything else**
-Lots of unittests from changes in this PR plus things from a branch leftover from Sprint 3.